### PR TITLE
Content planner: campaign JSON export + import (Phase 4a)

### DIFF
--- a/content_planner/chat_import.py
+++ b/content_planner/chat_import.py
@@ -1,0 +1,127 @@
+"""Create-from-chat import: turn pasted JSON into a campaign + posts.
+
+The write side of the Claude loop. Mirrors the export schema but deliberately
+asymmetric: ids and statuses in the JSON are ignored (every post starts
+DRAFTING), and only the planning fields are honored. The whole import runs in
+one transaction — any bad post aborts the lot.
+"""
+
+import datetime
+import json
+from zoneinfo import ZoneInfo
+
+from django.db import transaction
+
+from .models import Campaign, Post
+from .scheduling import compute_scheduled_at
+from .tagging import resolve_tags
+
+VALID_CHANNELS = {value for value, _ in Post.CHANNEL_CHOICES}
+ALL_DAY_DEFAULT_CHANNELS = {"blog", "newsletter"}
+
+
+class ChatImportError(ValueError):
+    """A user-facing problem with the pasted JSON."""
+
+
+def parse_chat_payload(raw):
+    """Parse and shape-check the pasted JSON. Raises ChatImportError."""
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ChatImportError(f"Invalid JSON: {exc}") from exc
+    if not isinstance(data, dict):
+        raise ChatImportError("Top-level JSON must be an object.")
+    campaign = data.get("campaign")
+    if not isinstance(campaign, dict) or not campaign.get("name"):
+        raise ChatImportError("Missing campaign.name.")
+    if not isinstance(data.get("posts"), list):
+        raise ChatImportError("Missing posts list.")
+    return data
+
+
+def _parse_date(value):
+    if not value:
+        return None
+    try:
+        return datetime.date.fromisoformat(value)
+    except (ValueError, TypeError) as exc:
+        raise ChatImportError(f"Invalid event_date '{value}'.") from exc
+
+
+def _parse_time(value):
+    if not value:
+        return None
+    try:
+        return datetime.time.fromisoformat(value)
+    except (ValueError, TypeError) as exc:
+        raise ChatImportError(f"Invalid time_of_day '{value}'.") from exc
+
+
+def _parse_datetime(value, tz_name):
+    try:
+        parsed = datetime.datetime.fromisoformat(value)
+    except (ValueError, TypeError) as exc:
+        raise ChatImportError(f"Invalid scheduled_at '{value}'.") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=ZoneInfo(tz_name))
+    return parsed
+
+
+def _build_post(campaign, board, data):
+    title = data.get("title")
+    channel = data.get("channel")
+    if not title:
+        raise ChatImportError("Each post needs a title.")
+    if channel not in VALID_CHANNELS:
+        raise ChatImportError(f"Unknown channel '{channel}' on post '{title}'.")
+
+    is_all_day = data.get("is_all_day")
+    if is_all_day is None:
+        is_all_day = channel in ALL_DAY_DEFAULT_CHANNELS
+
+    anchor = data.get("anchor_offset_days")
+    scheduled_at = None
+    if campaign.event_date is not None and anchor is not None:
+        scheduled_at = compute_scheduled_at(
+            event_date=campaign.event_date,
+            offset_days=anchor,
+            time_of_day=_parse_time(data.get("time_of_day")),
+            tz_name=board.timezone,
+        )
+    elif data.get("scheduled_at"):
+        scheduled_at = _parse_datetime(data["scheduled_at"], board.timezone)
+
+    return Post(
+        campaign=campaign,
+        title=title,
+        channel=channel,
+        scheduled_at=scheduled_at,
+        anchor_offset_days=anchor if campaign.event_date is not None else None,
+        is_all_day=bool(is_all_day),
+        status=Post.Status.DRAFTING,
+        body_snippet=data.get("body_snippet", "") or "",
+        expected_asset=data.get("expected_asset", "") or "",
+        notes=data.get("notes", "") or "",
+    )
+
+
+@transaction.atomic
+def create_campaign_from_payload(board, data, user):
+    """Create the campaign + posts from validated payload data."""
+    campaign_data = data["campaign"]
+    campaign = Campaign.objects.create(
+        board=board,
+        name=campaign_data["name"],
+        narrative_notes=campaign_data.get("narrative_notes", "") or "",
+        source_url=campaign_data.get("source_url", "") or "",
+        event_date=_parse_date(campaign_data.get("event_date")),
+    )
+    tag_names = [str(name) for name in campaign_data.get("tags") or []]
+    campaign.tags.set(resolve_tags(board, tag_names))
+
+    for post_data in data["posts"]:
+        post = _build_post(campaign, board, post_data)
+        post.created_by = user
+        post.save()
+    return campaign

--- a/content_planner/serialization.py
+++ b/content_planner/serialization.py
@@ -1,0 +1,74 @@
+"""Serialize a campaign to the export JSON shape.
+
+This is the read side of the Claude loop: a campaign's current state as JSON,
+in the same schema the create-from-chat importer consumes (plus extra fields
+the importer ignores — ids, statuses, timestamps, asset metadata). Datetimes
+render in the board's timezone.
+"""
+
+from zoneinfo import ZoneInfo
+
+
+def _iso_local(value, tz_name):
+    """ISO-8601 in the board's timezone, or None."""
+    if value is None:
+        return None
+    return value.astimezone(ZoneInfo(tz_name)).isoformat()
+
+
+def campaign_to_export_dict(campaign):
+    board = campaign.board
+    tz = board.timezone
+    posts = list(campaign.posts.select_related("created_by").prefetch_related("assets"))
+
+    assets = {}
+    for post in posts:
+        for asset in post.assets.all():
+            assets[asset.pk] = asset
+
+    return {
+        "campaign": {
+            "id": campaign.pk,
+            "slug": campaign.slug,
+            "name": campaign.name,
+            "tags": list(campaign.tags.values_list("name", flat=True)),
+            "event_date": (
+                campaign.event_date.isoformat() if campaign.event_date else None
+            ),
+            "narrative_notes": campaign.narrative_notes,
+            "source_url": campaign.source_url,
+            "creation_date": campaign.creation_date.isoformat(),
+            "modified_date": campaign.modified_date.isoformat(),
+        },
+        "posts": [
+            {
+                "id": post.pk,
+                "slug": post.slug,
+                "title": post.title,
+                "channel": post.channel,
+                "scheduled_at": _iso_local(post.scheduled_at, tz),
+                "is_all_day": post.is_all_day,
+                "anchor_offset_days": post.anchor_offset_days,
+                "status": post.status,
+                "body_snippet": post.body_snippet,
+                "draft_url": post.draft_url,
+                "published_url": post.published_url,
+                "expected_asset": post.expected_asset,
+                "notes": post.notes,
+                "created_by": (post.created_by.username if post.created_by else None),
+            }
+            for post in posts
+        ],
+        "assets": [
+            {
+                "id": asset.pk,
+                "name": asset.name,
+                "kind": asset.kind,
+                "caption": asset.caption,
+                "status": asset.status,
+                "source_url": asset.source_url,
+                "file_url": asset.file.url if asset.file else "",
+            }
+            for asset in assets.values()
+        ],
+    }

--- a/content_planner/templates/content_planner/campaign_detail.html
+++ b/content_planner/templates/content_planner/campaign_detail.html
@@ -30,6 +30,8 @@
         </div>
         <div class="text-nowrap">
             <a class="btn btn-sm btn-outline-secondary"
+               href="{% url 'content_planner:campaign_export' board.slug campaign.slug %}?view=html">View as JSON</a>
+            <a class="btn btn-sm btn-outline-secondary"
                href="{% url 'content_planner:campaign_edit' board.slug campaign.slug %}">Edit</a>
             <a class="btn btn-sm btn-primary"
                href="{% url 'content_planner:post_create' board.slug campaign.slug %}">+ Post</a>

--- a/content_planner/templates/content_planner/campaign_export.html
+++ b/content_planner/templates/content_planner/campaign_export.html
@@ -1,0 +1,46 @@
+{% extends "base.html" %}
+{% block head_title %}
+    Export · {{ campaign.name }} · {{ block.super }}
+{% endblock head_title %}
+{% block content %}
+    {% include "content_planner/_board_nav.html" with active="campaigns" %}
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item">
+                <a href="{% url 'content_planner:campaign_list' board.slug %}">Campaigns</a>
+            </li>
+            <li class="breadcrumb-item">
+                <a href="{% url 'content_planner:campaign_detail' board.slug campaign.slug %}">{{ campaign.name }}</a>
+            </li>
+            <li class="breadcrumb-item active" aria-current="page">
+                Export
+            </li>
+        </ol>
+    </nav>
+    <div class="d-flex justify-content-between align-items-center mb-2">
+        <h2 class="h4 mb-0">
+            {{ campaign.name }} — JSON
+        </h2>
+        <button type="button"
+                class="btn btn-sm btn-outline-secondary"
+                onclick="scCopyExport(this)">
+            Copy
+        </button>
+    </div>
+    <p class="text-muted">
+        Paste this back into a Claude chat as context, or save it as a backup.
+    </p>
+    <textarea id="sc-export" class="visually-hidden" readonly>{{ json_text }}</textarea>
+    <pre class="border rounded p-3" style="max-height: 70vh; overflow: auto">{{ json_text }}</pre>
+    <script>
+      function scCopyExport(btn) {
+        var ta = document.getElementById('sc-export');
+        if (!ta || !navigator.clipboard) return;
+        navigator.clipboard.writeText(ta.value).then(function () {
+          var old = btn.textContent;
+          btn.textContent = 'Copied!';
+          setTimeout(function () { btn.textContent = old; }, 1500);
+        });
+      }
+    </script>
+{% endblock content %}

--- a/content_planner/templates/content_planner/campaign_from_chat.html
+++ b/content_planner/templates/content_planner/campaign_from_chat.html
@@ -21,6 +21,64 @@
         Paste the JSON Claude produced. A campaign and its posts are created in one step —
         every post starts as a draft, and you can adjust them afterwards.
     </p>
+    <details class="mb-3">
+        <summary style="cursor: pointer">
+            JSON format — and a spec to give Claude
+        </summary>
+        <div class="mt-2">
+            <button type="button"
+                    class="btn btn-sm btn-outline-secondary mb-2"
+                    onclick="scCopySpec(this)">
+                Copy spec for Claude
+            </button>
+            <p class="small mb-1">
+                No ids needed — <code>id</code>, <code>slug</code>, and <code>status</code> are
+                ignored. Use <code>anchor_offset_days</code> when the campaign has an
+                <code>event_date</code>, otherwise <code>scheduled_at</code>.
+                Channels: <code>{{ channels }}</code>.
+            </p>
+            <textarea id="sc-spec" class="visually-hidden" readonly>{% verbatim %}Output the campaign as one JSON object in this exact shape. Do NOT include ids, slugs, or statuses — they are ignored, and every post is imported as a draft. Use anchor_offset_days (days relative to event_date; negative = before) when campaign.event_date is set; otherwise use scheduled_at (interpreted in the board's timezone).
+{
+  "campaign": {
+    "name": "string (required)",
+    "event_date": "YYYY-MM-DD (optional; set => event-anchored)",
+    "tags": ["string"],
+    "narrative_notes": "string"
+  },
+  "posts": [
+    {
+      "title": "string (required)",
+      "channel": "blog|mastodon|linkedin|x|instagram|newsletter|podcast|talk|other",
+      "anchor_offset_days": -90,
+      "time_of_day": "09:00",
+      "scheduled_at": "YYYY-MM-DDTHH:MM:SS",
+      "is_all_day": true,
+      "body_snippet": "string",
+      "expected_asset": "one expected asset per line",
+      "notes": "string"
+    }
+  ]
+}{% endverbatim %}</textarea>
+            <pre class="border rounded p-3 small" style="max-height: 40vh; overflow: auto">{% verbatim %}{
+  "campaign": { "name": "Confession series", "tags": ["advocacy"] },
+  "posts": [
+    { "title": "Part 1 — blog", "channel": "blog", "scheduled_at": "2026-05-30T00:00:00", "is_all_day": true },
+    { "title": "Part 1 — announce", "channel": "mastodon", "scheduled_at": "2026-05-30T09:00:00" }
+  ]
+}{% endverbatim %}</pre>
+        </div>
+    </details>
+    <script>
+      function scCopySpec(btn) {
+        var ta = document.getElementById('sc-spec');
+        if (!ta || !navigator.clipboard) return;
+        navigator.clipboard.writeText(ta.value).then(function () {
+          var old = btn.textContent;
+          btn.textContent = 'Copied!';
+          setTimeout(function () { btn.textContent = old; }, 1500);
+        });
+      }
+    </script>
     <form method="post">
         {% csrf_token %}
         <textarea name="payload"

--- a/content_planner/templates/content_planner/campaign_from_chat.html
+++ b/content_planner/templates/content_planner/campaign_from_chat.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block head_title %}
-    New from chat · {{ board.name }} · {{ block.super }}
+    Import campaign · {{ board.name }} · {{ block.super }}
 {% endblock head_title %}
 {% block content %}
     {% include "content_planner/_board_nav.html" with active="campaigns" %}
@@ -10,26 +10,27 @@
                 <a href="{% url 'content_planner:campaign_list' board.slug %}">Campaigns</a>
             </li>
             <li class="breadcrumb-item active" aria-current="page">
-                New from chat
+                Import JSON
             </li>
         </ol>
     </nav>
     <h2 class="h4 mb-2">
-        Import a campaign from a Claude chat
+        Import a campaign from JSON
     </h2>
     <p class="text-muted">
-        Paste the JSON Claude produced. A campaign and its posts are created in one step —
-        every post starts as a draft, and you can adjust them afterwards.
+        Paste a campaign as JSON — for example, what you planned with an AI assistant.
+        A campaign and its posts are created in one step; every post starts as a draft,
+        and you can adjust them afterwards.
     </p>
     <details class="mb-3">
         <summary style="cursor: pointer">
-            JSON format — and a spec to give Claude
+            JSON format — and a spec to give your AI tool
         </summary>
         <div class="mt-2">
             <button type="button"
                     class="btn btn-sm btn-outline-secondary mb-2"
                     onclick="scCopySpec(this)">
-                Copy spec for Claude
+                Copy spec
             </button>
             <p class="small mb-1">
                 No ids needed — <code>id</code>, <code>slug</code>, and <code>status</code> are

--- a/content_planner/templates/content_planner/campaign_from_chat.html
+++ b/content_planner/templates/content_planner/campaign_from_chat.html
@@ -1,0 +1,39 @@
+{% extends "base.html" %}
+{% block head_title %}
+    New from chat · {{ board.name }} · {{ block.super }}
+{% endblock head_title %}
+{% block content %}
+    {% include "content_planner/_board_nav.html" with active="campaigns" %}
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item">
+                <a href="{% url 'content_planner:campaign_list' board.slug %}">Campaigns</a>
+            </li>
+            <li class="breadcrumb-item active" aria-current="page">
+                New from chat
+            </li>
+        </ol>
+    </nav>
+    <h2 class="h4 mb-2">
+        Import a campaign from a Claude chat
+    </h2>
+    <p class="text-muted">
+        Paste the JSON Claude produced. A campaign and its posts are created in one step —
+        every post starts as a draft, and you can adjust them afterwards.
+    </p>
+    <form method="post">
+        {% csrf_token %}
+        <textarea name="payload"
+                  class="form-control mb-3"
+                  rows="16"
+                  spellcheck="false"
+                  placeholder='{&quot;campaign&quot;: {&quot;name&quot;: &quot;...&quot;}, &quot;posts&quot;: [...]}'>{{ payload }}</textarea>
+        <div class="d-flex justify-content-between">
+            <button type="submit" class="btn btn-primary">
+                Import
+            </button>
+            <a class="btn btn-outline-secondary"
+               href="{% url 'content_planner:campaign_list' board.slug %}">Cancel</a>
+        </div>
+    </form>
+{% endblock content %}

--- a/content_planner/templates/content_planner/campaign_list.html
+++ b/content_planner/templates/content_planner/campaign_list.html
@@ -6,7 +6,7 @@
     {% include "content_planner/_board_nav.html" with active="campaigns" %}
     <div class="d-flex justify-content-end gap-2 mb-3">
         <a class="btn btn-outline-secondary"
-           href="{% url 'content_planner:campaign_create_from_chat' board.slug %}">Import from chat</a>
+           href="{% url 'content_planner:campaign_create_from_chat' board.slug %}">Import JSON</a>
         <a class="btn btn-primary"
            href="{% url 'content_planner:campaign_create' board.slug %}">+ New campaign</a>
     </div>

--- a/content_planner/templates/content_planner/campaign_list.html
+++ b/content_planner/templates/content_planner/campaign_list.html
@@ -4,7 +4,9 @@
 {% endblock head_title %}
 {% block content %}
     {% include "content_planner/_board_nav.html" with active="campaigns" %}
-    <div class="d-flex justify-content-end mb-3">
+    <div class="d-flex justify-content-end gap-2 mb-3">
+        <a class="btn btn-outline-secondary"
+           href="{% url 'content_planner:campaign_create_from_chat' board.slug %}">Import from chat</a>
         <a class="btn btn-primary"
            href="{% url 'content_planner:campaign_create' board.slug %}">+ New campaign</a>
     </div>

--- a/content_planner/templates/content_planner/schedule.html
+++ b/content_planner/templates/content_planner/schedule.html
@@ -28,10 +28,10 @@
                 {% for week in grid.weeks %}
                     <tr>
                         {% for cell in week %}
-                            <td class="align-top{% if not cell.in_month %} bg-body-tertiary text-muted{% endif %}"
+                            <td class="align-top{% if not cell.in_month %} sc-cal-outside{% endif %}"
                                 style="width: 14.28%;
                                        height: 7rem">
-                                <div class="small mb-1{% if cell.date == today %} sc-today{% endif %}">
+                                <div class="small mb-1 sc-cal-daynum{% if cell.date == today %} sc-today{% endif %}">
                                     {{ cell.date.day }}
                                     {% if cell.date == today %}
                                         · today

--- a/content_planner/templates/content_planner/schedule.html
+++ b/content_planner/templates/content_planner/schedule.html
@@ -14,7 +14,7 @@
            href="?year={{ grid.next.year }}&month={{ grid.next.month }}">Next →</a>
     </div>
     <div class="table-responsive">
-        <table class="table table-bordered mb-0">
+        <table class="table table-bordered mb-0" style="table-layout: fixed">
             <thead>
                 <tr>
                     {% for header in grid.headers %}
@@ -42,7 +42,7 @@
                                         <span class="sc-status-dot sc-st-{{ post.status }}"
                                               title="{{ post.get_status_display }}"></span>
                                         <a class="small{% if post.is_overdue %} text-danger fw-semibold{% endif %}"
-                                           {% if post.is_overdue %}title="Overdue"{% endif %}
+                                           title="{{ post.title }}{% if post.is_overdue %} (overdue){% endif %}"
                                            href="{% url 'content_planner:post_detail' board.slug post.campaign.slug post.slug %}">
                                             {% if not post.is_all_day %}
                                                 {{ post.scheduled_at|date:"H:i" }}

--- a/content_planner/urls.py
+++ b/content_planner/urls.py
@@ -32,6 +32,16 @@ urlpatterns = [
         name="campaign_create",
     ),
     path(
+        "<slug:board_slug>/campaigns/new-from-chat/",
+        views.campaign_create_from_chat,
+        name="campaign_create_from_chat",
+    ),
+    path(
+        "<slug:board_slug>/c/<slug:slug>/export/",
+        views.campaign_export,
+        name="campaign_export",
+    ),
+    path(
         "<slug:board_slug>/c/<slug:slug>/",
         views.campaign_detail,
         name="campaign_detail",

--- a/content_planner/views.py
+++ b/content_planner/views.py
@@ -1,14 +1,20 @@
+import json
 from functools import wraps
 
 from django.contrib import messages
 from django.contrib.auth.decorators import user_passes_test
-from django.http import Http404
+from django.http import Http404, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.defaultfilters import pluralize
 from django.utils import timezone
 from django.views.decorators.http import require_http_methods
 
 from .billing import check_quota
+from .chat_import import (
+    ChatImportError,
+    create_campaign_from_payload,
+    parse_chat_payload,
+)
 from .forms import AssetForm, BoardForm, CampaignForm, PostCreateForm, PostForm
 from .models import Asset, Campaign, ContentBoard, Post
 from .permissions import can_access_board, is_content_user
@@ -18,6 +24,7 @@ from .selectors import (
     month_schedule,
     pending_summary,
 )
+from .serialization import campaign_to_export_dict
 
 
 def _accessible_boards(user):
@@ -149,6 +156,54 @@ def campaign_create(request, board):
         "content_planner/campaign_form.html",
         {"board": board, "form": form, "is_create": True},
     )
+
+
+@board_required
+@require_http_methods(["GET", "POST"])
+def campaign_create_from_chat(request, board):
+    """Paste a Claude-planned campaign as JSON and import it."""
+    raw = ""
+    if request.method == "POST":
+        raw = request.POST.get("payload", "")
+        try:
+            data = parse_chat_payload(raw)
+            campaign = create_campaign_from_payload(board, data, request.user)
+        except ChatImportError as exc:
+            messages.error(request, str(exc))
+        else:
+            messages.success(
+                request,
+                f"Imported '{campaign.name}' with "
+                f"{campaign.posts.count()} post{pluralize(campaign.posts.count())}.",
+            )
+            return redirect(
+                "content_planner:campaign_detail",
+                board_slug=board.slug,
+                slug=campaign.slug,
+            )
+    return render(
+        request,
+        "content_planner/campaign_from_chat.html",
+        {"board": board, "payload": raw},
+    )
+
+
+@board_required
+def campaign_export(request, board, slug):
+    """Campaign as JSON (machine), or an HTML wrapper with ?view=html."""
+    campaign = get_object_or_404(Campaign, board=board, slug=slug)
+    data = campaign_to_export_dict(campaign)
+    if request.GET.get("view") == "html":
+        return render(
+            request,
+            "content_planner/campaign_export.html",
+            {
+                "board": board,
+                "campaign": campaign,
+                "json_text": json.dumps(data, indent=2),
+            },
+        )
+    return JsonResponse(data, json_dumps_params={"indent": 2})
 
 
 @board_required

--- a/content_planner/views.py
+++ b/content_planner/views.py
@@ -184,7 +184,11 @@ def campaign_create_from_chat(request, board):
     return render(
         request,
         "content_planner/campaign_from_chat.html",
-        {"board": board, "payload": raw},
+        {
+            "board": board,
+            "payload": raw,
+            "channels": ", ".join(value for value, _ in Post.CHANNEL_CHOICES),
+        },
     )
 
 

--- a/handoff/content-planner-import-spec.md
+++ b/handoff/content-planner-import-spec.md
@@ -1,0 +1,108 @@
+# Content planner — create-from-chat JSON spec
+
+Paste this into a Claude chat so it produces JSON the **Import from chat**
+form (`/content/<board>/campaigns/new-from-chat/`) accepts.
+
+## Instruction to give Claude
+
+> Output the campaign as a single JSON object with this shape. Only use the
+> fields listed. Use `anchor_offset_days` when the campaign has an `event_date`,
+> otherwise use `scheduled_at`. Don't include ids or statuses — every post is
+> imported as a draft.
+
+## Schema
+
+```jsonc
+{
+  "campaign": {
+    "name": "string",                 // required
+    "event_date": "YYYY-MM-DD",        // optional; set ⇒ event-anchored campaign
+    "tags": ["string", ...],           // optional; created on the board if new
+    "narrative_notes": "string",       // optional
+    "source_url": "https://..."        // optional; link to the planning chat/doc
+  },
+  "posts": [
+    {
+      "title": "string",               // required — internal label
+      "channel": "blog",               // required — see channels below
+
+      // Scheduling — choose ONE style per post:
+      // (a) event-anchored (only when campaign.event_date is set):
+      "anchor_offset_days": -90,       // days relative to event_date (negative = before)
+      "time_of_day": "HH:MM",          // optional, 24h; defaults to 09:00
+      // (b) absolute date/time:
+      "scheduled_at": "YYYY-MM-DDTHH:MM:SS",  // no offset ⇒ interpreted in the board's timezone
+
+      "is_all_day": true,              // optional; default true for blog/newsletter, else false
+      "body_snippet": "string",        // optional; full text for socials, subject+preview for blog/newsletter
+      "expected_asset": "hero image\nsquare graphic",  // optional; one expected asset per line
+      "notes": "string"                // optional
+    }
+  ]
+}
+```
+
+## Channels
+
+`blog`, `mastodon`, `linkedin`, `x`, `instagram`, `newsletter`, `podcast`,
+`talk`, `other`.
+
+## What the importer ignores
+
+`id`, `slug`, `status`, `published_url`, `created_by`, timestamps, and asset
+file contents. Statuses are not honored — **every imported post starts as a
+draft**. Asset files must be uploaded in the app afterwards.
+
+## Example — event-anchored newsletter series
+
+```json
+{
+  "campaign": {
+    "name": "PyCon 2026 attendee comms",
+    "event_date": "2026-05-15",
+    "tags": ["pycon", "attendee-comms"],
+    "narrative_notes": "Attendee email series anchored to the conference dates."
+  },
+  "posts": [
+    {
+      "title": "Save the date",
+      "channel": "newsletter",
+      "anchor_offset_days": -90,
+      "time_of_day": "09:00",
+      "body_snippet": "Subject: Save the date for PyCon US 2026!\n\nHi everyone..."
+    },
+    {
+      "title": "Travel reminders",
+      "channel": "newsletter",
+      "anchor_offset_days": -14,
+      "expected_asset": "venue map"
+    }
+  ]
+}
+```
+
+## Example — non-event blog series with absolute dates
+
+```json
+{
+  "campaign": {
+    "name": "Conference-organizing confession series",
+    "tags": ["advocacy", "two-part series"]
+  },
+  "posts": [
+    {
+      "title": "Confession part 1 — blog",
+      "channel": "blog",
+      "scheduled_at": "2026-05-30T00:00:00",
+      "is_all_day": true,
+      "expected_asset": "hero image\nquote card"
+    },
+    {
+      "title": "Confession part 1 — announce",
+      "channel": "mastodon",
+      "scheduled_at": "2026-05-30T09:00:00",
+      "is_all_day": false
+    }
+  ]
+}
+```

--- a/handoff/content-planner-import-spec.md
+++ b/handoff/content-planner-import-spec.md
@@ -1,9 +1,9 @@
 # Content planner — create-from-chat JSON spec
 
-Paste this into a Claude chat so it produces JSON the **Import from chat**
+Paste this into your AI assistant's chat so it produces JSON the **Import JSON**
 form (`/content/<board>/campaigns/new-from-chat/`) accepts.
 
-## Instruction to give Claude
+## Instruction to give the AI assistant
 
 > Output the campaign as a single JSON object with this shape. Only use the
 > fields listed. Use `anchor_offset_days` when the campaign has an `event_date`,

--- a/secretcodes/static/brand/secret-codes.css
+++ b/secretcodes/static/brand/secret-codes.css
@@ -795,6 +795,16 @@ a:hover { color: var(--sc-accent); text-decoration-color: currentColor; }
   color: var(--sc-warn) !important;
 }
 
+/* Schedule calendar: cells from adjacent months. A theme-neutral grey tint
+   de-emphasizes them without dropping text to an unreadable muted colour
+   (Bootstrap's bg-body-tertiary + text-muted was illegible in dark mode). */
+.sc-cal-outside {
+  background-color: rgba(128, 128, 128, 0.12);
+}
+.sc-cal-outside .sc-cal-daynum {
+  opacity: 0.65;
+}
+
 /* Tell the browser which scheme native controls should use, so the
    date / datetime picker indicator (the little calendar icon) and form
    controls render with legible contrast in dark mode. Mirrors the

--- a/tests/test_content_planner_import_export.py
+++ b/tests/test_content_planner_import_export.py
@@ -1,0 +1,275 @@
+"""Export-as-JSON and create-from-chat import."""
+
+import datetime
+import json
+from zoneinfo import ZoneInfo
+
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+
+from content_planner.models import Asset, Campaign, ContentBoard, Post
+
+User = get_user_model()
+VAN = "America/Vancouver"
+
+
+@pytest.fixture
+def access_perm(db):
+    return Permission.objects.get(
+        codename="access_content_planner",
+        content_type__app_label="content_planner",
+    )
+
+
+@pytest.fixture
+def user(db, access_perm):
+    u = User.objects.create_user(username="owner", password="pw")
+    u.user_permissions.add(access_perm)
+    return u
+
+
+@pytest.fixture
+def board(user):
+    return ContentBoard.objects.create(
+        name="B", slug="ie-board", owner=user, timezone=VAN
+    )
+
+
+@pytest.fixture
+def auth_client(client, user):
+    client.force_login(user)
+    return client
+
+
+def _export_url(board, campaign):
+    return reverse(
+        "content_planner:campaign_export",
+        kwargs={"board_slug": board.slug, "slug": campaign.slug},
+    )
+
+
+def _import_url(board):
+    return reverse(
+        "content_planner:campaign_create_from_chat",
+        kwargs={"board_slug": board.slug},
+    )
+
+
+# ---------------------------------------------------------------- export
+
+
+def test_export_json_structure(auth_client, board, user, tmp_path, settings):
+    settings.MEDIA_ROOT = str(tmp_path)
+    campaign = Campaign.objects.create(board=board, name="Launch")
+    campaign.tags.set([board.tags.create(name="advocacy")])
+    post = Post.objects.create(
+        campaign=campaign,
+        title="Announce",
+        channel="mastodon",
+        status="ready",
+        created_by=user,
+        scheduled_at=datetime.datetime(2026, 5, 30, 16, 0, tzinfo=ZoneInfo("UTC")),
+    )
+    asset = Asset.objects.create(
+        board=board, name="Hero", file=SimpleUploadedFile("h.png", b"x")
+    )
+    post.assets.add(asset)
+
+    resp = auth_client.get(_export_url(board, campaign))
+    assert resp.status_code == 200
+    assert resp["Content-Type"] == "application/json"
+    data = resp.json()
+    assert data["campaign"]["name"] == "Launch"
+    assert data["campaign"]["tags"] == ["advocacy"]
+    assert data["posts"][0]["title"] == "Announce"
+    assert data["posts"][0]["created_by"] == "owner"
+    # 16:00 UTC is 09:00 in Vancouver (PDT)
+    assert data["posts"][0]["scheduled_at"].startswith("2026-05-30T09:00:00")
+    assert data["assets"][0]["name"] == "Hero"
+    assert data["assets"][0]["file_url"]
+
+
+def test_export_handles_nulls(auth_client, board):
+    campaign = Campaign.objects.create(board=board, name="Empty")
+    Post.objects.create(campaign=campaign, title="NoSched", channel="blog")
+    Asset.objects.create(board=board, name="SrcOnly", source_url="https://x/y.png")
+    resp = auth_client.get(_export_url(board, campaign))
+    data = resp.json()
+    assert data["campaign"]["event_date"] is None
+    assert data["posts"][0]["scheduled_at"] is None
+    assert data["posts"][0]["created_by"] is None
+    # asset isn't attached to a post, so it isn't in the export
+    assert data["assets"] == []
+
+
+def test_export_html_wrapper(auth_client, board):
+    campaign = Campaign.objects.create(board=board, name="Viewable")
+    resp = auth_client.get(_export_url(board, campaign), {"view": "html"})
+    assert resp.status_code == 200
+    assert b"Viewable" in resp.content
+    assert b"Copy" in resp.content
+
+
+# ---------------------------------------------------------------- import
+
+
+def test_import_get_renders_form(auth_client, board):
+    assert auth_client.get(_import_url(board)).status_code == 200
+
+
+def test_import_non_event_campaign(auth_client, board, user):
+    payload = {
+        "campaign": {"name": "Blog series", "tags": ["advocacy"]},
+        "posts": [
+            {
+                "title": "Part 1",
+                "channel": "blog",
+                "scheduled_at": "2026-05-30T00:00:00",
+                "status": "published",  # ignored
+            },
+            {
+                "title": "Announce",
+                "channel": "mastodon",
+                "scheduled_at": "2026-05-30T09:00:00",
+            },
+        ],
+    }
+    resp = auth_client.post(_import_url(board), {"payload": json.dumps(payload)})
+    assert resp.status_code == 302
+    campaign = Campaign.objects.get(name="Blog series")
+    assert set(campaign.tags.values_list("name", flat=True)) == {"advocacy"}
+    posts = list(campaign.posts.all())
+    assert len(posts) == 2
+    assert all(p.status == "drafting" for p in posts)  # status forced
+    assert all(p.created_by == user for p in posts)
+    blog = campaign.posts.get(channel="blog")
+    assert blog.is_all_day is True  # default for blog
+    assert blog.scheduled_at is not None
+    assert campaign.posts.get(channel="mastodon").is_all_day is False
+
+
+def test_import_event_anchored(auth_client, board):
+    payload = {
+        "campaign": {"name": "PyCon comms", "event_date": "2026-05-15"},
+        "posts": [
+            {
+                "title": "Save the date",
+                "channel": "newsletter",
+                "anchor_offset_days": -90,
+                "time_of_day": "09:00",
+            }
+        ],
+    }
+    resp = auth_client.post(_import_url(board), {"payload": json.dumps(payload)})
+    assert resp.status_code == 302
+    post = Post.objects.get(title="Save the date")
+    assert post.anchor_offset_days == -90
+    local = post.scheduled_at.astimezone(ZoneInfo(VAN))
+    assert local.date() == datetime.date(2026, 2, 14)
+    assert local.time() == datetime.time(9, 0)
+
+
+def test_import_anchored_without_time_defaults_0900(auth_client, board):
+    payload = {
+        "campaign": {"name": "Ev", "event_date": "2026-05-15"},
+        "posts": [{"title": "T", "channel": "newsletter", "anchor_offset_days": -1}],
+    }
+    auth_client.post(_import_url(board), {"payload": json.dumps(payload)})
+    post = Post.objects.get(title="T")
+    assert post.scheduled_at.astimezone(ZoneInfo(VAN)).time() == datetime.time(9, 0)
+
+
+def test_import_event_campaign_post_without_dates(auth_client, board):
+    payload = {
+        "campaign": {"name": "Ev", "event_date": "2026-05-15"},
+        "posts": [{"title": "TBD", "channel": "blog"}],
+    }
+    auth_client.post(_import_url(board), {"payload": json.dumps(payload)})
+    post = Post.objects.get(title="TBD")
+    assert post.scheduled_at is None
+    assert post.anchor_offset_days is None
+
+
+def test_import_aware_datetime_preserved(auth_client, board):
+    payload = {
+        "campaign": {"name": "Aware"},
+        "posts": [
+            {"title": "P", "channel": "x", "scheduled_at": "2026-05-30T09:00:00-07:00"}
+        ],
+    }
+    auth_client.post(_import_url(board), {"payload": json.dumps(payload)})
+    post = Post.objects.get(title="P")
+    assert post.scheduled_at.astimezone(ZoneInfo(VAN)).hour == 9
+
+
+@pytest.mark.parametrize(
+    "payload,fragment",
+    [
+        ("not json {", "Invalid JSON"),
+        ('["a list"]', "must be an object"),
+        ('{"posts": []}', "campaign.name"),
+        ('{"campaign": {"name": "X"}}', "posts list"),
+        (
+            '{"campaign": {"name": "X", "event_date": "nope"}, "posts": []}',
+            "event_date",
+        ),
+        (
+            '{"campaign": {"name": "X"}, "posts": [{"channel": "blog"}]}',
+            "needs a title",
+        ),
+        (
+            '{"campaign": {"name": "X"}, "posts": [{"title": "T", "channel": "zzz"}]}',
+            "Unknown channel",
+        ),
+    ],
+)
+def test_import_errors(auth_client, board, payload, fragment):
+    resp = auth_client.post(_import_url(board), {"payload": payload})
+    assert resp.status_code == 200
+    assert not Campaign.objects.filter(board=board).exists()
+    if fragment:
+        assert fragment.encode() in resp.content
+
+
+def test_import_bad_time_of_day_for_anchored(auth_client, board):
+    payload = {
+        "campaign": {"name": "Ev", "event_date": "2026-05-15"},
+        "posts": [
+            {
+                "title": "T",
+                "channel": "newsletter",
+                "anchor_offset_days": -1,
+                "time_of_day": "99:99",
+            }
+        ],
+    }
+    resp = auth_client.post(_import_url(board), {"payload": json.dumps(payload)})
+    assert resp.status_code == 200
+    assert b"time_of_day" in resp.content
+    assert not Campaign.objects.filter(name="Ev").exists()  # rolled back
+
+
+def test_import_bad_scheduled_at(auth_client, board):
+    payload = {
+        "campaign": {"name": "Bad"},
+        "posts": [{"title": "T", "channel": "blog", "scheduled_at": "not-a-date"}],
+    }
+    resp = auth_client.post(_import_url(board), {"payload": json.dumps(payload)})
+    assert resp.status_code == 200
+    assert b"scheduled_at" in resp.content
+
+
+def test_export_import_round_trip(auth_client, board):
+    source = Campaign.objects.create(board=board, name="Source", event_date=None)
+    Post.objects.create(
+        campaign=source, title="Orig", channel="blog", status="published"
+    )
+    exported = auth_client.get(_export_url(board, source)).json()
+    # Feed the export straight back in as a new campaign.
+    exported["campaign"]["name"] = "Imported copy"
+    auth_client.post(_import_url(board), {"payload": json.dumps(exported)})
+    copy = Campaign.objects.get(name="Imported copy")
+    assert copy.posts.get().status == "drafting"  # never PUBLISHED on import


### PR DESCRIPTION
## What

Adds the import/export half of the Claude loop to `content_planner` — bring an AI-planned campaign into the tracker, and get a campaign back out as JSON. (The read-only MCP server is the remaining Phase 4a piece, not in this PR.)

## Export-as-JSON
- **`/content/<board>/c/<slug>/export/`** returns the campaign as indented JSON (`application/json`), or a readable HTML page with a **Copy** button via `?view=html`.
- Includes campaign + posts (times in the board's timezone) + attached-asset metadata, plus ids/statuses/`created_by`/timestamps. A **View as JSON** button is on the campaign detail page. (`serialization.py`)

## Create-from-chat import
- **`/content/<board>/campaigns/new-from-chat/`** ("Import JSON") parses pasted JSON and creates the campaign + posts in one transaction. (`chat_import.py`)
- Deliberately asymmetric: **ids / slugs / statuses are ignored** — every imported post starts **DRAFTING**, `created_by` is the importer. Event-anchored (`anchor_offset_days` + `time_of_day`) and absolute (`scheduled_at`) scheduling are both honored; tags resolved against the board; all-day defaults per channel. Any bad post aborts the whole import with a clear message.
- The import page shows a collapsible **JSON format reference** with a copyable spec and the valid channel list (also in `handoff/content-planner-import-spec.md`). Wording is tool-agnostic (JSON / "AI assistant", not Claude-specific).

## Also in this PR (UI fixes found while testing)
- Schedule calendar: `table-layout: fixed` so long post titles truncate instead of breaking the grid (full title on hover).
- Schedule calendar: out-of-month cells now legible in dark mode.

## Tests
`tests/test_content_planner_import_export.py` covers export (JSON + HTML + nulls + tz), import (event-anchored, absolute, aware datetimes, tag resolution, status-forced-draft, all-day defaults, round-trip) and every error path. Full suite green at **100% coverage**; lint and `makemigrations --check` clean (no schema changes).