### PR TITLE
Content planner: bulk-update posts from the campaign list

### DIFF
--- a/content_planner/templates/content_planner/_post_row.html
+++ b/content_planner/templates/content_planner/_post_row.html
@@ -1,7 +1,16 @@
-{% comment %}One post line. Expects `board` and `post`.{% endcomment %}
+{% comment %}One post line. Expects `board` and `post`. Pass `selectable` to add a
+bulk-select checkbox (associated with the campaign's #bulk-form).{% endcomment %}
 {% load icons %}
-<li class="list-group-item d-flex justify-content-between align-items-center">
-    <span>
+<li class="list-group-item d-flex align-items-center gap-2">
+    {% if selectable %}
+        <input type="checkbox"
+               class="form-check-input flex-shrink-0"
+               name="posts"
+               value="{{ post.pk }}"
+               form="bulk-form"
+               aria-label="Select {{ post.title }}">
+    {% endif %}
+    <span class="flex-grow-1">
         <a href="{% url 'content_planner:post_detail' board.slug post.campaign.slug post.slug %}">{{ post.title }}</a>
         <small class="text-muted">· {{ post.get_channel_display }} · {{ post.campaign.name }}</small>
     </span>

--- a/content_planner/templates/content_planner/campaign_detail.html
+++ b/content_planner/templates/content_planner/campaign_detail.html
@@ -107,11 +107,53 @@
         Posts
     </h3>
     {% if posts %}
+        {# Bulk actions: a standalone form; row checkboxes associate via form="bulk-form". #}
+        <form id="bulk-form"
+              method="post"
+              action="{% url 'content_planner:campaign_bulk_update' board.slug campaign.slug %}"
+              class="d-flex flex-wrap gap-2 align-items-center mb-2">
+            {% csrf_token %}
+            <div class="form-check mb-0">
+                <input type="checkbox"
+                       class="form-check-input"
+                       id="bulk-all"
+                       onclick="scBulkAll(this)">
+                <label class="form-check-label small" for="bulk-all">
+                    Select all
+                </label>
+            </div>
+            <select name="action"
+                    class="form-select form-select-sm w-auto"
+                    aria-label="Bulk action">
+                <option value="set_status">
+                    Set status
+                </option>
+            </select>
+            <select name="status"
+                    class="form-select form-select-sm w-auto"
+                    aria-label="Status">
+                {% for value, label in status_choices %}
+                    <option value="{{ value }}">
+                        {{ label }}
+                    </option>
+                {% endfor %}
+            </select>
+            <button type="submit" class="btn btn-sm btn-primary">
+                Apply to selected
+            </button>
+        </form>
         <ul class="list-group">
             {% for post in posts %}
-                {% include "content_planner/_post_row.html" %}
+                {% include "content_planner/_post_row.html" with selectable=True %}
             {% endfor %}
         </ul>
+        <script>
+          function scBulkAll(master) {
+            document.querySelectorAll('input[name="posts"]').forEach(function (c) {
+              c.checked = master.checked;
+            });
+          }
+        </script>
     {% else %}
         <p class="text-muted">
             No posts yet.

--- a/content_planner/urls.py
+++ b/content_planner/urls.py
@@ -52,6 +52,11 @@ urlpatterns = [
         name="campaign_edit",
     ),
     path(
+        "<slug:board_slug>/c/<slug:slug>/bulk/",
+        views.campaign_bulk_update,
+        name="campaign_bulk_update",
+    ),
+    path(
         "<slug:board_slug>/c/<slug:slug>/p/new/",
         views.post_create,
         name="post_create",

--- a/content_planner/views.py
+++ b/content_planner/views.py
@@ -268,9 +268,7 @@ def campaign_bulk_update(request, board, slug):
         status = request.POST.get("status")
         if status in Post.Status.values:
             posts.update(status=status, modified_date=timezone.now())
-            messages.success(
-                request, f"Updated {count} post{pluralize(count)}."
-            )
+            messages.success(request, f"Updated {count} post{pluralize(count)}.")
         else:
             messages.error(request, "Pick a valid status.")
     else:

--- a/content_planner/views.py
+++ b/content_planner/views.py
@@ -245,7 +245,40 @@ def campaign_detail(request, board, slug):
             "campaign": campaign,
             "posts": posts,
             "stats": campaign_stats(campaign),
+            "status_choices": Post.Status.choices,
         },
+    )
+
+
+@board_required
+@require_http_methods(["POST"])
+def campaign_bulk_update(request, board, slug):
+    """Apply a bulk action to the selected posts in a campaign.
+
+    Dispatches on ``action`` so new bulk operations are a single branch to add.
+    v1 supports ``set_status``.
+    """
+    campaign = get_object_or_404(Campaign, board=board, slug=slug)
+    posts = campaign.posts.filter(pk__in=request.POST.getlist("posts"))
+    count = posts.count()
+    action = request.POST.get("action")
+    if not count:
+        messages.info(request, "No posts selected.")
+    elif action == "set_status":
+        status = request.POST.get("status")
+        if status in Post.Status.values:
+            posts.update(status=status, modified_date=timezone.now())
+            messages.success(
+                request, f"Updated {count} post{pluralize(count)}."
+            )
+        else:
+            messages.error(request, "Pick a valid status.")
+    else:
+        messages.error(request, "Pick a bulk action.")
+    return redirect(
+        "content_planner:campaign_detail",
+        board_slug=board.slug,
+        slug=campaign.slug,
     )
 
 

--- a/tests/test_content_planner_views.py
+++ b/tests/test_content_planner_views.py
@@ -440,6 +440,64 @@ def test_post_edit_get(auth_client, board, campaign):
     assert resp.status_code == 200
 
 
+def _bulk_url(board, campaign):
+    return reverse(
+        "content_planner:campaign_bulk_update",
+        kwargs={"board_slug": board.slug, "slug": campaign.slug},
+    )
+
+
+def test_bulk_set_status_updates_selected(auth_client, board, campaign):
+    p1 = Post.objects.create(campaign=campaign, title="A", channel="blog")
+    p2 = Post.objects.create(campaign=campaign, title="B", channel="blog")
+    resp = auth_client.post(
+        _bulk_url(board, campaign),
+        {"posts": [p1.pk, p2.pk], "action": "set_status", "status": "published"},
+    )
+    assert resp.status_code == 302
+    p1.refresh_from_db()
+    p2.refresh_from_db()
+    assert p1.status == "published"
+    assert p2.status == "published"
+
+
+def test_bulk_no_selection_changes_nothing(auth_client, board, campaign):
+    post = Post.objects.create(
+        campaign=campaign, title="A", channel="blog", status="drafting"
+    )
+    resp = auth_client.post(
+        _bulk_url(board, campaign), {"action": "set_status", "status": "published"}
+    )
+    assert resp.status_code == 302
+    post.refresh_from_db()
+    assert post.status == "drafting"
+
+
+def test_bulk_invalid_status_rejected(auth_client, board, campaign):
+    post = Post.objects.create(
+        campaign=campaign, title="A", channel="blog", status="drafting"
+    )
+    resp = auth_client.post(
+        _bulk_url(board, campaign),
+        {"posts": [post.pk], "action": "set_status", "status": "bogus"},
+    )
+    assert resp.status_code == 302
+    post.refresh_from_db()
+    assert post.status == "drafting"
+
+
+def test_bulk_unknown_action_rejected(auth_client, board, campaign):
+    post = Post.objects.create(
+        campaign=campaign, title="A", channel="blog", status="drafting"
+    )
+    resp = auth_client.post(
+        _bulk_url(board, campaign), {"posts": [post.pk], "action": "frobnicate"}
+    )
+    assert resp.status_code == 302
+    post.refresh_from_db()
+    assert post.status == "drafting"
+
+
 def test_post_delete(auth_client, board, campaign):
     post = Post.objects.create(campaign=campaign, title="Doomed", channel="blog")
     resp = auth_client.post(


### PR DESCRIPTION
## What

Adds bulk actions to the campaign's post list so you can select multiple posts and apply an update in one go (e.g. set status / mark as done). Designed to be **extensible** — future bulk operations are a single dispatch branch.

## How
- A bulk-action bar above the post list: **Select all**, an **action** dropdown (v1: *Set status*), a **status** dropdown, and **Apply to selected**.
- Each post row gets a checkbox. The bar is a standalone `#bulk-form`; row checkboxes associate to it via the HTML `form="bulk-form"` attribute, so they don't nest inside the per-row delete forms (which would be invalid HTML).
- New `campaign_bulk_update` view **dispatches on `action`**. v1 handles `set_status` (which also covers "mark as done" → set to Published). Adding bulk-shift / archive / etc. later is one more `elif`.
- Bulk status update uses `queryset.update(...)` with a refreshed `modified_date`.

## Tests
Set-status applies to selected posts; empty selection is a no-op; invalid status and unknown action are rejected. Full suite green at **100% coverage**; lint + `makemigrations --check` clean.

Independent of #96 (the tagify sourcemap hotfix) — no shared files.