### PR TITLE
Content planner: offer JSON import from the empty board overview

### DIFF
--- a/content_planner/templates/content_planner/board_home.html
+++ b/content_planner/templates/content_planner/board_home.html
@@ -5,17 +5,24 @@
 {% block content %}
     {% include "content_planner/_board_nav.html" with active="overview" %}
     {% if board.campaigns.exists %}
-        <div class="d-flex justify-content-end mb-3">
+        <div class="d-flex justify-content-end gap-2 mb-3">
+            <a class="btn btn-outline-secondary"
+               href="{% url 'content_planner:campaign_create_from_chat' board.slug %}">Import JSON</a>
             <a class="btn btn-primary"
                href="{% url 'content_planner:campaign_create' board.slug %}">+ New campaign</a>
         </div>
     {% else %}
         <div class="border rounded p-4 text-center mb-4">
             <p class="mb-3">
-                This board has no campaigns yet. Create one, then add posts to it.
+                This board has no campaigns yet. Create one (or import a JSON campaign),
+                then add posts to it.
             </p>
-            <a class="btn btn-primary"
-               href="{% url 'content_planner:campaign_create' board.slug %}">Create your first campaign</a>
+            <div class="d-flex justify-content-center gap-2">
+                <a class="btn btn-primary"
+                   href="{% url 'content_planner:campaign_create' board.slug %}">Create your first campaign</a>
+                <a class="btn btn-outline-secondary"
+                   href="{% url 'content_planner:campaign_create_from_chat' board.slug %}">Import JSON</a>
+            </div>
         </div>
     {% endif %}
     {% with overdue=sections.overdue today=sections.today week=sections.this_week awaiting=sections.awaiting recent=sections.recently_published %}

--- a/tests/test_content_planner_views.py
+++ b/tests/test_content_planner_views.py
@@ -100,6 +100,19 @@ def test_board_home_renders_for_owner(auth_client, board):
     assert b"Today" in resp.content
 
 
+def test_board_home_empty_state_offers_import(auth_client, board):
+    """With no campaigns, the overview still links to JSON import — importing
+    is a way to create your first campaign."""
+    resp = auth_client.get(
+        reverse("content_planner:board_home", kwargs={"board_slug": board.slug})
+    )
+    import_url = reverse(
+        "content_planner:campaign_create_from_chat",
+        kwargs={"board_slug": board.slug},
+    )
+    assert import_url.encode() in resp.content
+
+
 def test_no_external_script_or_style_resources(auth_client, board):
     """Guard: all JS/CSS is served locally — no CDNs (and thus no third-party
     cookies). Fails if a template ever adds an external script/stylesheet."""


### PR DESCRIPTION
## Problem

On the board **overview**, when a board has no campaigns yet, the empty state only offered *Create your first campaign* — no **Import JSON**. But importing a JSON campaign is itself a way to create that first campaign, so the option was missing exactly when it's most useful. (The Campaigns tab always showed Import JSON; the overview didn't.)

## Fix

Add **Import JSON** to the overview in both states:
- the empty state (next to *Create your first campaign*), and
- the populated header (next to *+ New campaign*).

Test asserts the empty-state overview links to the import view. Full suite green at 100% coverage; lint clean.