### PR TITLE
Content planner: JSON Schema resources for the import format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,7 @@ lint: .state/docker-build-web
 	docker compose run --rm web djlint . --lint
 	docker compose run --rm web flake8
 	docker compose run --rm web python manage.py makemigrations --check --settings=secretcodes.settings
+	docker compose run --rm web python manage.py rebuild_content_schemas --check
 
 reformat: .state/docker-build-web
 	docker compose run --rm web isort .

--- a/content_planner/chat_import.py
+++ b/content_planner/chat_import.py
@@ -11,12 +11,14 @@ import json
 from zoneinfo import ZoneInfo
 
 from django.db import transaction
+from jsonschema import Draft202012Validator
+from jsonschema.exceptions import best_match
 
 from .models import Campaign, Post
 from .scheduling import compute_scheduled_at
+from .schemas import build_create_from_chat_schema
 from .tagging import resolve_tags
 
-VALID_CHANNELS = {value for value, _ in Post.CHANNEL_CHOICES}
 ALL_DAY_DEFAULT_CHANNELS = {"blog", "newsletter"}
 
 
@@ -25,18 +27,22 @@ class ChatImportError(ValueError):
 
 
 def parse_chat_payload(raw):
-    """Parse and shape-check the pasted JSON. Raises ChatImportError."""
+    """Parse the pasted JSON and check it against the create-from-chat schema.
+
+    Structure (required fields, types, the channel enum) is validated here;
+    date/time values are parsed later with their own precise errors. Raises
+    ChatImportError on the first problem.
+    """
     try:
         data = json.loads(raw)
     except json.JSONDecodeError as exc:
         raise ChatImportError(f"Invalid JSON: {exc}") from exc
-    if not isinstance(data, dict):
-        raise ChatImportError("Top-level JSON must be an object.")
-    campaign = data.get("campaign")
-    if not isinstance(campaign, dict) or not campaign.get("name"):
-        raise ChatImportError("Missing campaign.name.")
-    if not isinstance(data.get("posts"), list):
-        raise ChatImportError("Missing posts list.")
+    validator = Draft202012Validator(build_create_from_chat_schema())
+    error = best_match(validator.iter_errors(data))
+    if error is not None:
+        location = ".".join(str(part) for part in error.absolute_path)
+        where = f"{location}: " if location else ""
+        raise ChatImportError(f"{where}{error.message}")
     return data
 
 
@@ -71,11 +77,6 @@ def _parse_datetime(value, tz_name):
 def _build_post(campaign, board, data):
     title = data.get("title")
     channel = data.get("channel")
-    if not title:
-        raise ChatImportError("Each post needs a title.")
-    if channel not in VALID_CHANNELS:
-        raise ChatImportError(f"Unknown channel '{channel}' on post '{title}'.")
-
     is_all_day = data.get("is_all_day")
     if is_all_day is None:
         is_all_day = channel in ALL_DAY_DEFAULT_CHANNELS

--- a/content_planner/management/commands/rebuild_content_schemas.py
+++ b/content_planner/management/commands/rebuild_content_schemas.py
@@ -1,0 +1,51 @@
+"""Regenerate (or verify) the committed content_planner JSON Schema files.
+
+The schemas are derived from the models, so this keeps the committed files in
+``content_planner/schemas/`` in sync with channel/status changes. CI runs it
+with ``--check`` to fail the build if the model changed but the schema didn't.
+"""
+
+import json
+
+from django.core.management.base import BaseCommand, CommandError
+
+from content_planner import schemas
+
+FILES = {
+    "create_from_chat.schema.json": "build_create_from_chat_schema",
+    "export.schema.json": "build_export_schema",
+}
+
+
+def _render(builder_name):
+    return json.dumps(getattr(schemas, builder_name)(), indent=2) + "\n"
+
+
+class Command(BaseCommand):
+    help = "Regenerate content_planner JSON Schema files from the models."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--check",
+            action="store_true",
+            help="Exit non-zero if a committed schema is out of date.",
+        )
+
+    def handle(self, *args, check=False, **options):
+        stale = []
+        for name, builder_name in FILES.items():
+            path = schemas.SCHEMA_DIR / name
+            content = _render(builder_name)
+            if check:
+                current = path.read_text() if path.exists() else None
+                if current != content:
+                    stale.append(name)
+            else:
+                path.write_text(content)
+                self.stdout.write(f"wrote {path}")
+        if stale:
+            raise CommandError(
+                "Out-of-date schema(s): "
+                + ", ".join(stale)
+                + ". Run `./manage.py rebuild_content_schemas`."
+            )

--- a/content_planner/mcp.py
+++ b/content_planner/mcp.py
@@ -1,0 +1,154 @@
+"""MCP server (JSON-RPC 2.0 over HTTP POST) for the content_planner format.
+
+Resources-only and read-only: serves the create-from-chat schema, the
+conventions doc, and worked examples as MCP resources, so an AI tool added as a
+connector can read the JSON shape itself instead of guessing — no private board
+data, so no auth.
+
+Hand-rolled to mirror ``availability.services.mcp``: this is a sync WSGI app and
+the async MCP SDK's remote transport doesn't fit it, so a small JSON-RPC adapter
+in a plain Django view is the pragmatic, proven choice (it's how the
+availability connector already runs).
+"""
+
+from .schemas import SCHEMA_DIR
+
+PROTOCOL_VERSION = "2025-06-18"
+SUPPORTED_PROTOCOL_VERSIONS = frozenset({"2024-11-05", "2025-03-26", "2025-06-18"})
+SERVER_INFO = {"name": "secretcodes-content-planner", "version": "1.0.0"}
+
+
+class ResourceNotFound(Exception):
+    """Raised when resources/read references an unknown URI."""
+
+
+RESOURCES = {
+    "schema://content/create-from-chat": {
+        "file": "create_from_chat.schema.json",
+        "name": "Create-from-chat JSON Schema",
+        "description": (
+            "JSON Schema for the campaign import (create-from-chat) format."
+        ),
+        "mime": "application/schema+json",
+    },
+    "schema://content/export": {
+        "file": "export.schema.json",
+        "name": "Campaign export JSON Schema",
+        "description": (
+            "JSON Schema for the campaign export format (superset of "
+            "create-from-chat)."
+        ),
+        "mime": "application/schema+json",
+    },
+    "docs://content/conventions": {
+        "file": "conventions.md",
+        "name": "Content planner JSON conventions",
+        "description": (
+            "How to produce a campaign JSON: channels, scheduling, hashtags, "
+            "and which fields are ignored on import."
+        ),
+        "mime": "text/markdown",
+    },
+    "example://content/event-anchored-campaign": {
+        "file": "examples/event-anchored-campaign.json",
+        "name": "Example: event-anchored campaign",
+        "description": (
+            "A complete, valid create-from-chat payload anchored to an event " "date."
+        ),
+        "mime": "application/json",
+    },
+    "example://content/blog-and-social-series": {
+        "file": "examples/blog-and-social-series.json",
+        "name": "Example: blog + social series",
+        "description": (
+            "A complete, valid create-from-chat payload with absolute " "scheduling."
+        ),
+        "mime": "application/json",
+    },
+}
+
+
+def _resource_descriptor(uri):
+    res = RESOURCES[uri]
+    return {
+        "uri": uri,
+        "name": res["name"],
+        "description": res["description"],
+        "mimeType": res["mime"],
+    }
+
+
+def _handle_initialize(params):
+    requested = params.get("protocolVersion")
+    negotiated = (
+        requested if requested in SUPPORTED_PROTOCOL_VERSIONS else PROTOCOL_VERSION
+    )
+    return {
+        "protocolVersion": negotiated,
+        "capabilities": {"resources": {}},
+        "serverInfo": SERVER_INFO,
+    }
+
+
+def _handle_resources_list(params):
+    return {"resources": [_resource_descriptor(uri) for uri in RESOURCES]}
+
+
+def _handle_resources_read(params):
+    uri = params.get("uri")
+    if uri not in RESOURCES:
+        raise ResourceNotFound(f"Unknown resource: {uri!r}")
+    return {
+        "contents": [
+            {
+                "uri": uri,
+                "mimeType": RESOURCES[uri]["mime"],
+                "text": (SCHEMA_DIR / RESOURCES[uri]["file"]).read_text(),
+            }
+        ]
+    }
+
+
+def _handle_tools_list(params):
+    return {"tools": []}
+
+
+METHODS = {
+    "initialize": _handle_initialize,
+    "resources/list": _handle_resources_list,
+    "resources/read": _handle_resources_read,
+    "tools/list": _handle_tools_list,
+}
+
+
+def _error(code, message, request_id):
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {"code": code, "message": message},
+    }
+
+
+def dispatch(payload):
+    """Return the JSON-RPC 2.0 response dict, or ``None`` for notifications.
+
+    A payload without an ``id`` is a notification — per the spec the server
+    sends no response, so the caller returns HTTP 202 with an empty body.
+    """
+    if "id" not in payload:
+        return None
+
+    request_id = payload.get("id")
+    method = payload.get("method")
+
+    if method not in METHODS:
+        return _error(-32601, f"Method not found: {method!r}", request_id)
+
+    try:
+        result = METHODS[method](payload.get("params") or {})
+    except ResourceNotFound as exc:
+        return _error(-32602, str(exc), request_id)
+    except Exception as exc:
+        return _error(-32603, f"Internal error: {exc}", request_id)
+
+    return {"jsonrpc": "2.0", "id": request_id, "result": result}

--- a/content_planner/schemas.py
+++ b/content_planner/schemas.py
@@ -1,0 +1,196 @@
+"""JSON Schemas for the content_planner import/export formats.
+
+The create-from-chat schema is the contract an agent (Claude or otherwise)
+follows when producing a campaign JSON, and the same structure the import
+parser checks on submit, so "what the agent was told" and "what the form
+accepts" cannot drift. Channel and status enums are read from the models, so a
+new channel shows up in the schema the moment it lands in code.
+
+Regenerate the committed files in ``content_planner/schemas/`` with
+``./manage.py rebuild_content_schemas`` (CI runs it with ``--check``).
+"""
+
+from pathlib import Path
+
+from django.conf import settings
+
+from .models import Post
+
+SCHEMA_DIR = Path(settings.BASE_DIR) / "content_planner" / "schemas"
+
+DRAFT = "https://json-schema.org/draft/2020-12/schema"
+
+
+def _channels():
+    return [value for value, _ in Post.CHANNEL_CHOICES]
+
+
+def _statuses():
+    return [value for value, _ in Post.Status.choices]
+
+
+def build_create_from_chat_schema():
+    """Schema for the create-from-chat import (one campaign + its posts).
+
+    Lenient like the importer: unknown keys (id, slug, status, created_by,
+    server-computed dates) are allowed and ignored, so an exported campaign can
+    be re-imported untouched. Every imported post starts in ``drafting``.
+    """
+    return {
+        "$schema": DRAFT,
+        "$id": "schema://content/create-from-chat",
+        "title": "Content planner - create campaign from chat",
+        "description": (
+            "Input for the create-from-chat import: one campaign and its posts. "
+            "Extra keys (id, slug, status, created_by, server-computed dates) are "
+            "ignored. Every imported post starts in 'drafting'."
+        ),
+        "type": "object",
+        "required": ["campaign", "posts"],
+        "properties": {
+            "campaign": {
+                "type": "object",
+                "required": ["name"],
+                "properties": {
+                    "name": {"type": "string", "minLength": 1},
+                    "event_date": {
+                        "type": ["string", "null"],
+                        "format": "date",
+                        "description": (
+                            "ISO date (YYYY-MM-DD). When set, posts may use "
+                            "anchor_offset_days to schedule relative to it."
+                        ),
+                    },
+                    "narrative_notes": {"type": "string"},
+                    "source_url": {
+                        "type": "string",
+                        "description": "Link to the planning chat or doc.",
+                    },
+                    "hashtags": {
+                        "type": "string",
+                        "description": (
+                            "Default hashtags for this campaign's social posts, "
+                            "space- or comma-separated, e.g. '#PyLadiesCon #Python'."
+                        ),
+                    },
+                    "tags": {
+                        "type": "array",
+                        "items": {"type": "string"},
+                        "description": "Board-level tags; created if new.",
+                    },
+                },
+            },
+            "posts": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "required": ["title", "channel"],
+                    "properties": {
+                        "title": {"type": "string", "minLength": 1},
+                        "channel": {"type": "string", "enum": _channels()},
+                        "scheduled_at": {
+                            "type": ["string", "null"],
+                            "format": "date-time",
+                            "description": (
+                                "ISO datetime. Used when the post is not "
+                                "event-anchored. A naive value assumes the board "
+                                "timezone. null = unscheduled."
+                            ),
+                        },
+                        "anchor_offset_days": {
+                            "type": ["integer", "null"],
+                            "description": (
+                                "Days from the campaign's event_date (negative = "
+                                "before). Honored only when event_date is set."
+                            ),
+                        },
+                        "time_of_day": {
+                            "type": "string",
+                            "format": "time",
+                            "description": (
+                                "ISO time (HH:MM), paired with anchor_offset_days."
+                            ),
+                        },
+                        "is_all_day": {
+                            "type": "boolean",
+                            "description": (
+                                "Defaults to true for blog/newsletter, else false."
+                            ),
+                        },
+                        "body_snippet": {"type": "string"},
+                        "expected_asset": {
+                            "type": "string",
+                            "description": ("Assets this post expects, one per line."),
+                        },
+                        "hashtags": {
+                            "type": "string",
+                            "description": (
+                                "Extra hashtags for this post, added to the "
+                                "campaign's. Used on social channels."
+                            ),
+                        },
+                        "notes": {"type": "string"},
+                    },
+                },
+            },
+        },
+    }
+
+
+def build_export_schema():
+    """Schema for the campaign export JSON (superset of create-from-chat)."""
+    schema = {
+        "$schema": DRAFT,
+        "$id": "schema://content/export",
+        "title": "Content planner - campaign export",
+        "description": (
+            "Full export shape for a campaign. A superset of create-from-chat: "
+            "re-importing ignores id, slug, status, created_by and the dates."
+        ),
+        "type": "object",
+        "required": ["campaign", "posts"],
+        "properties": {
+            "campaign": {
+                "type": "object",
+                "properties": {
+                    "id": {"type": "integer"},
+                    "slug": {"type": "string"},
+                    "name": {"type": "string"},
+                    "tags": {"type": "array", "items": {"type": "string"}},
+                    "event_date": {"type": ["string", "null"], "format": "date"},
+                    "narrative_notes": {"type": "string"},
+                    "source_url": {"type": "string"},
+                    "hashtags": {"type": "string"},
+                    "creation_date": {"type": "string", "format": "date-time"},
+                    "modified_date": {"type": "string", "format": "date-time"},
+                },
+            },
+            "posts": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "integer"},
+                        "slug": {"type": "string"},
+                        "title": {"type": "string"},
+                        "channel": {"type": "string", "enum": _channels()},
+                        "scheduled_at": {
+                            "type": ["string", "null"],
+                            "format": "date-time",
+                        },
+                        "is_all_day": {"type": "boolean"},
+                        "anchor_offset_days": {"type": ["integer", "null"]},
+                        "status": {"type": "string", "enum": _statuses()},
+                        "body_snippet": {"type": "string"},
+                        "draft_url": {"type": "string"},
+                        "published_url": {"type": "string"},
+                        "expected_asset": {"type": "string"},
+                        "hashtags": {"type": "string"},
+                        "notes": {"type": "string"},
+                        "created_by": {"type": ["string", "null"]},
+                    },
+                },
+            },
+        },
+    }
+    return schema

--- a/content_planner/schemas/conventions.md
+++ b/content_planner/schemas/conventions.md
@@ -1,0 +1,77 @@
+# Content planner — JSON conventions
+
+How to produce a campaign JSON for the **create-from-chat** import. The machine
+contract is `create_from_chat.schema.json` (same dir); this is the *why* behind
+it. Both are generated/kept in sync with the models — don't guess field names.
+
+## Shape
+
+```json
+{
+  "campaign": { "name": "..." },
+  "posts": [ { "title": "...", "channel": "..." } ]
+}
+```
+
+Top level needs `campaign` (object) and `posts` (array). A campaign needs a
+`name`; each post needs a `title` and a `channel`. Everything else is optional.
+
+## Channels
+
+`channel` must be one of (read from the model, so this list is authoritative in
+the schema's `enum`): `blog`, `mastodon`, `linkedin`, `x`, `instagram`,
+`newsletter`, `podcast`, `talk`, `other`.
+
+Social channels (`mastodon`, `linkedin`, `x`, `instagram`) are where hashtags
+get appended when copying.
+
+## Status lifecycle (and why you don't set it)
+
+Posts move through `drafting → ready → uploaded → scheduled → published`, plus
+`archived` / `cancelled`. **The import ignores any `status` you send — every
+imported post starts in `drafting`.** Status is something the human moves the
+post through in the UI, not something the plan declares.
+
+## Scheduling: two mutually exclusive ways
+
+1. **Event-anchored.** Set `campaign.event_date` (ISO `YYYY-MM-DD`), then give
+   each post an `anchor_offset_days` integer (negative = before the event) and
+   optionally a `time_of_day` (`HH:MM`). The server computes the real datetime
+   in the board's timezone. Use this for conference / meetup comms.
+2. **Absolute.** Leave `event_date` unset and give a post a `scheduled_at` ISO
+   datetime. A naive value (no offset) is interpreted in the board's timezone.
+
+If a campaign has an `event_date` but a post has neither field, the post is left
+unscheduled. `anchor_offset_days` is only honored when `event_date` is set.
+
+## All-day
+
+`is_all_day` defaults to `true` for `blog` and `newsletter`, `false` otherwise.
+Set it explicitly to override.
+
+## Hashtags
+
+`campaign.hashtags` is the default set for the campaign's social posts;
+`post.hashtags` adds extras for one post. Both are a single string, space- or
+comma-separated, with or without the leading `#` (e.g. `"#PyLadiesCon Python"`).
+
+## Assets
+
+`expected_asset` is a single string listing the assets a post expects, **one per
+line**. It's a planning checklist; the actual files are attached later in the UI.
+
+## Slugs and ids — leave them out
+
+Slugs and ids are server-generated and board-scoped. Don't invent them; any
+`id`/`slug` you include is ignored (so an exported campaign re-imports cleanly).
+
+## Ignored vs honored on import
+
+- **Honored:** campaign `name`, `event_date`, `narrative_notes`, `source_url`,
+  `hashtags`, `tags`; post `title`, `channel`, `scheduled_at`,
+  `anchor_offset_days`, `time_of_day`, `is_all_day`, `body_snippet`,
+  `expected_asset`, `hashtags`, `notes`.
+- **Ignored:** `id`, `slug`, `status`, `created_by`, and any server-computed
+  dates (`creation_date`, `modified_date`). Sending them is harmless.
+
+See `examples/` for two complete, valid payloads.

--- a/content_planner/schemas/create_from_chat.schema.json
+++ b/content_planner/schemas/create_from_chat.schema.json
@@ -1,0 +1,119 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schema://content/create-from-chat",
+  "title": "Content planner - create campaign from chat",
+  "description": "Input for the create-from-chat import: one campaign and its posts. Extra keys (id, slug, status, created_by, server-computed dates) are ignored. Every imported post starts in 'drafting'.",
+  "type": "object",
+  "required": [
+    "campaign",
+    "posts"
+  ],
+  "properties": {
+    "campaign": {
+      "type": "object",
+      "required": [
+        "name"
+      ],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "event_date": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date",
+          "description": "ISO date (YYYY-MM-DD). When set, posts may use anchor_offset_days to schedule relative to it."
+        },
+        "narrative_notes": {
+          "type": "string"
+        },
+        "source_url": {
+          "type": "string",
+          "description": "Link to the planning chat or doc."
+        },
+        "hashtags": {
+          "type": "string",
+          "description": "Default hashtags for this campaign's social posts, space- or comma-separated, e.g. '#PyLadiesCon #Python'."
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "description": "Board-level tags; created if new."
+        }
+      }
+    },
+    "posts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": [
+          "title",
+          "channel"
+        ],
+        "properties": {
+          "title": {
+            "type": "string",
+            "minLength": 1
+          },
+          "channel": {
+            "type": "string",
+            "enum": [
+              "blog",
+              "mastodon",
+              "linkedin",
+              "x",
+              "instagram",
+              "newsletter",
+              "podcast",
+              "talk",
+              "other"
+            ]
+          },
+          "scheduled_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time",
+            "description": "ISO datetime. Used when the post is not event-anchored. A naive value assumes the board timezone. null = unscheduled."
+          },
+          "anchor_offset_days": {
+            "type": [
+              "integer",
+              "null"
+            ],
+            "description": "Days from the campaign's event_date (negative = before). Honored only when event_date is set."
+          },
+          "time_of_day": {
+            "type": "string",
+            "format": "time",
+            "description": "ISO time (HH:MM), paired with anchor_offset_days."
+          },
+          "is_all_day": {
+            "type": "boolean",
+            "description": "Defaults to true for blog/newsletter, else false."
+          },
+          "body_snippet": {
+            "type": "string"
+          },
+          "expected_asset": {
+            "type": "string",
+            "description": "Assets this post expects, one per line."
+          },
+          "hashtags": {
+            "type": "string",
+            "description": "Extra hashtags for this post, added to the campaign's. Used on social channels."
+          },
+          "notes": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  }
+}

--- a/content_planner/schemas/examples/blog-and-social-series.json
+++ b/content_planner/schemas/examples/blog-and-social-series.json
@@ -1,0 +1,31 @@
+{
+  "campaign": {
+    "name": "Confessions blog series",
+    "narrative_notes": "A weekly long-form blog post, each amplified with a social teaser.",
+    "hashtags": "#PyLadiesCon"
+  },
+  "posts": [
+    {
+      "title": "Confession #1: I never read the docs",
+      "channel": "blog",
+      "scheduled_at": "2026-07-06T08:00:00",
+      "is_all_day": true,
+      "body_snippet": "The first in a weekly series of honest developer confessions.",
+      "expected_asset": "cover image",
+      "notes": "Pillar post; the social posts below point back to this."
+    },
+    {
+      "title": "Teaser for confession #1",
+      "channel": "mastodon",
+      "scheduled_at": "2026-07-06T15:30:00",
+      "body_snippet": "New post: the docs and I have a complicated relationship.",
+      "hashtags": "#DeveloperLife"
+    },
+    {
+      "title": "Teaser for confession #1 (LinkedIn)",
+      "channel": "linkedin",
+      "scheduled_at": "2026-07-07T16:00:00",
+      "body_snippet": "This week's confession is about the docs nobody reads."
+    }
+  ]
+}

--- a/content_planner/schemas/examples/event-anchored-campaign.json
+++ b/content_planner/schemas/examples/event-anchored-campaign.json
@@ -1,0 +1,35 @@
+{
+  "campaign": {
+    "name": "PyCon attendee comms",
+    "event_date": "2026-05-14",
+    "narrative_notes": "Build excitement before the conference, then keep attendees informed during it.",
+    "source_url": "https://example.com/planning-chat",
+    "hashtags": "#PyCon #Python",
+    "tags": ["conference", "attendee-comms"]
+  },
+  "posts": [
+    {
+      "title": "Save the date announcement",
+      "channel": "blog",
+      "anchor_offset_days": -30,
+      "is_all_day": true,
+      "body_snippet": "PyCon is one month away. Here is what to expect and how to prepare.",
+      "expected_asset": "hero banner\nsocial share card"
+    },
+    {
+      "title": "Schedule is live",
+      "channel": "mastodon",
+      "anchor_offset_days": -7,
+      "time_of_day": "09:00",
+      "body_snippet": "The full talk schedule is up. Plan your week!",
+      "hashtags": "#PyConSchedule"
+    },
+    {
+      "title": "Day 1 welcome",
+      "channel": "x",
+      "anchor_offset_days": 0,
+      "time_of_day": "08:30",
+      "body_snippet": "Welcome to PyCon, day one! Stop by the registration desk."
+    }
+  ]
+}

--- a/content_planner/schemas/export.schema.json
+++ b/content_planner/schemas/export.schema.json
@@ -1,0 +1,140 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "schema://content/export",
+  "title": "Content planner - campaign export",
+  "description": "Full export shape for a campaign. A superset of create-from-chat: re-importing ignores id, slug, status, created_by and the dates.",
+  "type": "object",
+  "required": [
+    "campaign",
+    "posts"
+  ],
+  "properties": {
+    "campaign": {
+      "type": "object",
+      "properties": {
+        "id": {
+          "type": "integer"
+        },
+        "slug": {
+          "type": "string"
+        },
+        "name": {
+          "type": "string"
+        },
+        "tags": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "event_date": {
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "narrative_notes": {
+          "type": "string"
+        },
+        "source_url": {
+          "type": "string"
+        },
+        "hashtags": {
+          "type": "string"
+        },
+        "creation_date": {
+          "type": "string",
+          "format": "date-time"
+        },
+        "modified_date": {
+          "type": "string",
+          "format": "date-time"
+        }
+      }
+    },
+    "posts": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer"
+          },
+          "slug": {
+            "type": "string"
+          },
+          "title": {
+            "type": "string"
+          },
+          "channel": {
+            "type": "string",
+            "enum": [
+              "blog",
+              "mastodon",
+              "linkedin",
+              "x",
+              "instagram",
+              "newsletter",
+              "podcast",
+              "talk",
+              "other"
+            ]
+          },
+          "scheduled_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "format": "date-time"
+          },
+          "is_all_day": {
+            "type": "boolean"
+          },
+          "anchor_offset_days": {
+            "type": [
+              "integer",
+              "null"
+            ]
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "drafting",
+              "ready",
+              "uploaded",
+              "scheduled",
+              "published",
+              "archived",
+              "cancelled"
+            ]
+          },
+          "body_snippet": {
+            "type": "string"
+          },
+          "draft_url": {
+            "type": "string"
+          },
+          "published_url": {
+            "type": "string"
+          },
+          "expected_asset": {
+            "type": "string"
+          },
+          "hashtags": {
+            "type": "string"
+          },
+          "notes": {
+            "type": "string"
+          },
+          "created_by": {
+            "type": [
+              "string",
+              "null"
+            ]
+          }
+        }
+      }
+    }
+  }
+}

--- a/content_planner/templates/content_planner/campaign_from_chat.html
+++ b/content_planner/templates/content_planner/campaign_from_chat.html
@@ -22,6 +22,9 @@
         A campaign and its posts are created in one step; every post starts as a draft,
         and you can adjust them afterwards.
     </p>
+    <p>
+        <a href="{% url 'content_planner:import_help' board.slug %}">Format guide &amp; worked examples →</a>
+    </p>
     <details class="mb-3">
         <summary style="cursor: pointer">
             JSON format — and a spec to give your AI tool

--- a/content_planner/templates/content_planner/import_help.html
+++ b/content_planner/templates/content_planner/import_help.html
@@ -24,6 +24,39 @@
         The same contract an AI assistant follows when generating a campaign JSON.
         Hand it (or paste it) to your assistant so it produces valid JSON the first time.
     </p>
+    {% load icons %}
+    <div class="border rounded p-3 mb-4 sc-bg-subtle">
+        <div class="d-flex justify-content-between align-items-center gap-2">
+            <div>
+                <div class="fw-bold">
+                    Use with your AI tool
+                </div>
+                <div class="text-muted small">
+                    Paste this once into your AI tool (e.g. a Claude Project's instructions).
+                    Then just ask it to plan a campaign — it'll produce JSON you paste below.
+                </div>
+            </div>
+            <button type="button"
+                    class="btn btn-primary flex-shrink-0"
+                    onclick="scCopy('sc-ai-instructions', this)">
+                {% icon "copy" class="me-1" %}<span data-copy-label>Copy AI instructions</span>
+            </button>
+        </div>
+        <textarea id="sc-ai-instructions" class="visually-hidden" readonly>{{ ai_instructions }}</textarea>
+        <hr class="my-3">
+        <div class="small">
+            <span class="fw-bold">Or add a connector</span> (Claude Desktop / a custom
+            connector) so you never paste again — point it at this MCP endpoint:
+            <div class="d-flex align-items-center gap-2 mt-1">
+                <code id="sc-mcp-url" class="flex-grow-1 text-break">{{ mcp_url }}</code>
+                <button type="button"
+                        class="btn btn-sm btn-outline-secondary flex-shrink-0"
+                        onclick="scCopy('sc-mcp-url', this)">
+                    {% icon "copy" class="me-1" %}<span data-copy-label>Copy</span>
+                </button>
+            </div>
+        </div>
+    </div>
     <div class="sc-prose">
         {{ conventions_html|safe }}
     </div>

--- a/content_planner/templates/content_planner/import_help.html
+++ b/content_planner/templates/content_planner/import_help.html
@@ -1,0 +1,47 @@
+{% extends "base.html" %}
+{% block head_title %}
+    Import format guide · {{ board.name }} · {{ block.super }}
+{% endblock head_title %}
+{% block content %}
+    {% include "content_planner/_board_nav.html" with active="campaigns" %}
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item">
+                <a href="{% url 'content_planner:campaign_list' board.slug %}">Campaigns</a>
+            </li>
+            <li class="breadcrumb-item">
+                <a href="{% url 'content_planner:campaign_create_from_chat' board.slug %}">Import JSON</a>
+            </li>
+            <li class="breadcrumb-item active" aria-current="page">
+                Format guide
+            </li>
+        </ol>
+    </nav>
+    <h2 class="h4 mb-3">
+        Import format guide
+    </h2>
+    <p class="text-muted">
+        The same contract an AI assistant follows when generating a campaign JSON.
+        Hand it (or paste it) to your assistant so it produces valid JSON the first time.
+    </p>
+    <div class="sc-prose">
+        {{ conventions_html|safe }}
+    </div>
+    <h3 class="h5 mt-4">
+        Worked examples
+    </h3>
+    {% for example in examples %}
+        <div class="d-flex justify-content-between align-items-center mb-1 mt-3">
+            <div class="fw-bold">
+                {{ example.name }}
+            </div>
+            <button type="button"
+                    class="btn btn-sm btn-outline-secondary"
+                    onclick="scCopy('sc-example-{{ forloop.counter }}', this)">
+                {% load icons %}
+                {% icon "copy" class="me-1" %}<span data-copy-label>Copy</span>
+            </button>
+        </div>
+        <pre class="border rounded p-3"><code id="sc-example-{{ forloop.counter }}">{{ example.content }}</code></pre>
+    {% endfor %}
+{% endblock content %}

--- a/content_planner/urls.py
+++ b/content_planner/urls.py
@@ -37,6 +37,11 @@ urlpatterns = [
         name="campaign_create_from_chat",
     ),
     path(
+        "<slug:board_slug>/campaigns/import-help/",
+        views.import_help,
+        name="import_help",
+    ),
+    path(
         "<slug:board_slug>/c/<slug:slug>/export/",
         views.campaign_export,
         name="campaign_export",

--- a/content_planner/views.py
+++ b/content_planner/views.py
@@ -1,6 +1,7 @@
 import json
 from functools import wraps
 
+import markdown
 from django.contrib import messages
 from django.contrib.auth.decorators import user_passes_test
 from django.http import Http404, JsonResponse
@@ -18,6 +19,7 @@ from .chat_import import (
 from .forms import AssetForm, BoardForm, CampaignForm, PostCreateForm, PostForm
 from .models import Asset, Campaign, ContentBoard, Post
 from .permissions import can_access_board, is_content_user
+from .schemas import SCHEMA_DIR
 from .selectors import (
     campaign_stats,
     daily_sections,
@@ -188,6 +190,29 @@ def campaign_create_from_chat(request, board):
             "board": board,
             "payload": raw,
             "channels": ", ".join(value for value, _ in Post.CHANNEL_CHOICES),
+        },
+    )
+
+
+@board_required
+def import_help(request, board):
+    """Human-readable view of the create-from-chat format: the conventions doc
+    plus the worked examples that agents consume as schema resources."""
+    examples = [
+        {"name": path.stem, "content": path.read_text()}
+        for path in sorted((SCHEMA_DIR / "examples").glob("*.json"))
+    ]
+    conventions_html = markdown.markdown(
+        (SCHEMA_DIR / "conventions.md").read_text(),
+        extensions=["fenced_code", "tables"],
+    )
+    return render(
+        request,
+        "content_planner/import_help.html",
+        {
+            "board": board,
+            "conventions_html": conventions_html,
+            "examples": examples,
         },
     )
 

--- a/content_planner/views.py
+++ b/content_planner/views.py
@@ -2,13 +2,17 @@ import json
 from functools import wraps
 
 import markdown
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import user_passes_test
-from django.http import Http404, JsonResponse
+from django.http import Http404, HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.defaultfilters import pluralize
+from django.urls import reverse
 from django.utils import timezone
-from django.views.decorators.http import require_http_methods
+from django.views.decorators.csrf import csrf_exempt
+from django.views.decorators.http import require_http_methods, require_POST
+from django_ratelimit.decorators import ratelimit
 
 from .billing import check_quota
 from .chat_import import (
@@ -17,6 +21,7 @@ from .chat_import import (
     parse_chat_payload,
 )
 from .forms import AssetForm, BoardForm, CampaignForm, PostCreateForm, PostForm
+from .mcp import dispatch as mcp_dispatch
 from .models import Asset, Campaign, ContentBoard, Post
 from .permissions import can_access_board, is_content_user
 from .schemas import SCHEMA_DIR
@@ -196,15 +201,27 @@ def campaign_create_from_chat(request, board):
 
 @board_required
 def import_help(request, board):
-    """Human-readable view of the create-from-chat format: the conventions doc
-    plus the worked examples that agents consume as schema resources."""
+    """The create-from-chat format for humans: the rendered conventions, the
+    worked examples, and a one-click instruction block to paste into an AI tool
+    so it produces valid JSON without guessing the shape."""
     examples = [
         {"name": path.stem, "content": path.read_text()}
         for path in sorted((SCHEMA_DIR / "examples").glob("*.json"))
     ]
+    conventions_md = (SCHEMA_DIR / "conventions.md").read_text()
+    schema_json = (SCHEMA_DIR / "create_from_chat.schema.json").read_text()
     conventions_html = markdown.markdown(
-        (SCHEMA_DIR / "conventions.md").read_text(),
-        extensions=["fenced_code", "tables"],
+        conventions_md, extensions=["fenced_code", "tables"]
+    )
+    ai_instructions = (
+        "When I ask you to plan a content campaign, reply with ONLY a JSON "
+        "object in exactly the format below — no prose, no markdown fences. "
+        "I will paste it into a content planner.\n\n"
+        "# Conventions\n\n"
+        f"{conventions_md}\n\n"
+        "# JSON Schema (authoritative)\n\n"
+        f"{schema_json}\n\n"
+        "# Examples\n\n" + "\n\n".join(example["content"] for example in examples)
     )
     return render(
         request,
@@ -213,6 +230,8 @@ def import_help(request, board):
             "board": board,
             "conventions_html": conventions_html,
             "examples": examples,
+            "ai_instructions": ai_instructions,
+            "mcp_url": request.build_absolute_uri(reverse("content_mcp_endpoint")),
         },
     )
 
@@ -436,3 +455,43 @@ def asset_archive(request, board, pk):
     asset.save()
     messages.success(request, f"Archived '{asset.name}'.")
     return redirect("content_planner:asset_list", board_slug=board.slug)
+
+
+def _mcp_rate(group, request):
+    return settings.MCP_RATE_LIMIT
+
+
+@csrf_exempt
+@require_POST
+@ratelimit(key="ip", rate=_mcp_rate, block=False)
+def content_mcp_endpoint(request):
+    """MCP server for the content_planner format — JSON-RPC 2.0 over HTTP POST.
+
+    Resources-only (schema, conventions, examples); no private board data, so
+    no auth. Add this URL as a custom connector in your AI tool. Mirrors the
+    availability MCP endpoint.
+    """
+    if getattr(request, "limited", False):
+        return JsonResponse(
+            {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32000, "message": "Rate limit exceeded"},
+            },
+            status=429,
+        )
+    try:
+        payload = json.loads(request.body)
+    except json.JSONDecodeError:
+        return JsonResponse(
+            {
+                "jsonrpc": "2.0",
+                "id": None,
+                "error": {"code": -32700, "message": "Parse error"},
+            },
+            status=400,
+        )
+    response_payload = mcp_dispatch(payload)
+    if response_payload is None:
+        return HttpResponse(status=202)
+    return JsonResponse(response_payload)

--- a/requirements.txt
+++ b/requirements.txt
@@ -22,6 +22,7 @@ django-widget-tweaks==1.5.1
 google-api-python-client==2.196.0
 google-auth==2.53.0
 google-auth-oauthlib==1.4.0
+jsonschema==4.26.0
 pillow==12.2.0
 qrcode==8.2
 qrcode[pil]

--- a/secretcodes/urls.py
+++ b/secretcodes/urls.py
@@ -21,6 +21,7 @@ from django.contrib import admin
 from django.urls import include, path
 
 from availability import views as availability_views
+from content_planner import views as content_planner_views
 from qrcode_manager import views as qr_views
 from secretcodes import views
 
@@ -34,6 +35,12 @@ urlpatterns = [
     path("content/", include("content_planner.urls")),
     path("mcp/", availability_views.mcp_endpoint, name="mcp_endpoint"),
     path("mcp", availability_views.mcp_endpoint),
+    path(
+        "mcp/content/",
+        content_planner_views.content_mcp_endpoint,
+        name="content_mcp_endpoint",
+    ),
+    path("mcp/content", content_planner_views.content_mcp_endpoint),
     path(".well-known/mcp.json", views.well_known_mcp, name="well_known_mcp"),
     path("agents/", views.agents, name="agents"),
     path("about/", views.about, name="about"),

--- a/tests/test_content_planner_import_export.py
+++ b/tests/test_content_planner_import_export.py
@@ -70,6 +70,8 @@ def test_import_help_renders_conventions_and_examples(auth_client, board):
     assert b"event-anchored-campaign" in resp.content  # example shown
     assert b"PyCon attendee comms" in resp.content  # example content
     assert b"Channels" in resp.content  # rendered from conventions.md
+    assert b"Copy AI instructions" in resp.content  # paste-once block
+    assert b"/mcp/content/" in resp.content  # connector URL shown
 
 
 # ---------------------------------------------------------------- export

--- a/tests/test_content_planner_import_export.py
+++ b/tests/test_content_planner_import_export.py
@@ -58,6 +58,20 @@ def _import_url(board):
     )
 
 
+# ------------------------------------------------------------ import help
+
+
+def test_import_help_renders_conventions_and_examples(auth_client, board):
+    resp = auth_client.get(
+        reverse("content_planner:import_help", kwargs={"board_slug": board.slug})
+    )
+    assert resp.status_code == 200
+    assert b"Import format guide" in resp.content
+    assert b"event-anchored-campaign" in resp.content  # example shown
+    assert b"PyCon attendee comms" in resp.content  # example content
+    assert b"Channels" in resp.content  # rendered from conventions.md
+
+
 # ---------------------------------------------------------------- export
 
 
@@ -209,20 +223,20 @@ def test_import_aware_datetime_preserved(auth_client, board):
     "payload,fragment",
     [
         ("not json {", "Invalid JSON"),
-        ('["a list"]', "must be an object"),
-        ('{"posts": []}', "campaign.name"),
-        ('{"campaign": {"name": "X"}}', "posts list"),
+        ('["a list"]', "is not of type"),
+        ('{"posts": []}', "is a required property"),
+        ('{"campaign": {"name": "X"}}', "is a required property"),
         (
             '{"campaign": {"name": "X", "event_date": "nope"}, "posts": []}',
             "event_date",
         ),
         (
             '{"campaign": {"name": "X"}, "posts": [{"channel": "blog"}]}',
-            "needs a title",
+            "posts.0",
         ),
         (
             '{"campaign": {"name": "X"}, "posts": [{"title": "T", "channel": "zzz"}]}',
-            "Unknown channel",
+            "is not one of",
         ),
     ],
 )

--- a/tests/test_content_planner_mcp.py
+++ b/tests/test_content_planner_mcp.py
@@ -1,0 +1,166 @@
+"""Content planner MCP server (resources-only) — JSON-RPC 2.0 over HTTP POST."""
+
+import json
+
+import pytest
+from django.core.cache import cache
+from django.urls import reverse
+
+from content_planner.mcp import (
+    PROTOCOL_VERSION,
+    RESOURCES,
+    SUPPORTED_PROTOCOL_VERSIONS,
+    dispatch,
+)
+
+pytestmark = pytest.mark.django_db
+
+
+def _jsonrpc(method, params=None, request_id=1):
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "method": method,
+        "params": params or {},
+    }
+
+
+def _post(client, payload):
+    return client.post(
+        reverse("content_mcp_endpoint"),
+        data=json.dumps(payload),
+        content_type="application/json",
+    )
+
+
+# ---------- transport + dispatcher ----------
+
+
+def test_endpoint_returns_parse_error_for_invalid_json(client):
+    resp = client.post(
+        reverse("content_mcp_endpoint"),
+        data="not json",
+        content_type="application/json",
+    )
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == -32700
+
+
+def test_endpoint_method_not_found(client):
+    assert _post(client, _jsonrpc("nonsense/method")).json()["error"]["code"] == -32601
+
+
+def test_endpoint_preserves_request_id(client):
+    assert _post(client, _jsonrpc("initialize", request_id="abc")).json()["id"] == "abc"
+
+
+def test_notification_returns_202_no_body(client):
+    resp = client.post(
+        reverse("content_mcp_endpoint"),
+        data=json.dumps({"jsonrpc": "2.0", "method": "notifications/initialized"}),
+        content_type="application/json",
+    )
+    assert resp.status_code == 202
+    assert resp.content == b""
+
+
+def test_dispatch_returns_none_for_notifications():
+    assert dispatch({"jsonrpc": "2.0", "method": "notifications/initialized"}) is None
+
+
+def test_endpoint_accepts_post_without_trailing_slash(client):
+    resp = client.post(
+        "/mcp/content",
+        data=json.dumps(_jsonrpc("initialize")),
+        content_type="application/json",
+    )
+    assert resp.status_code == 200
+
+
+def test_dispatch_internal_error_when_handler_raises(monkeypatch):
+    monkeypatch.setitem(
+        RESOURCES,
+        "schema://content/create-from-chat",
+        {"file": "does-not-exist.json", "name": "x", "description": "x", "mime": "x"},
+    )
+    resp = dispatch(
+        _jsonrpc("resources/read", {"uri": "schema://content/create-from-chat"})
+    )
+    assert resp["error"]["code"] == -32603
+
+
+# ---------- initialize ----------
+
+
+def test_initialize_returns_protocol_and_server_info(client):
+    result = _post(client, _jsonrpc("initialize")).json()["result"]
+    assert result["protocolVersion"] == PROTOCOL_VERSION
+    assert result["serverInfo"]["name"] == "secretcodes-content-planner"
+    assert "resources" in result["capabilities"]
+
+
+@pytest.mark.parametrize("version", sorted(SUPPORTED_PROTOCOL_VERSIONS))
+def test_initialize_echoes_supported_version(client, version):
+    result = _post(client, _jsonrpc("initialize", {"protocolVersion": version})).json()[
+        "result"
+    ]
+    assert result["protocolVersion"] == version
+
+
+def test_initialize_falls_back_for_unknown_version(client):
+    result = _post(
+        client, _jsonrpc("initialize", {"protocolVersion": "1999-01-01"})
+    ).json()["result"]
+    assert result["protocolVersion"] == PROTOCOL_VERSION
+
+
+# ---------- resources ----------
+
+
+def test_resources_list_returns_all_uris(client):
+    resources = _post(client, _jsonrpc("resources/list")).json()["result"]["resources"]
+    uris = {r["uri"] for r in resources}
+    assert uris == set(RESOURCES)
+    assert all(r["mimeType"] and r["name"] for r in resources)
+
+
+def test_resources_read_returns_schema_body(client):
+    result = _post(
+        client,
+        _jsonrpc("resources/read", {"uri": "schema://content/create-from-chat"}),
+    ).json()["result"]
+    content = result["contents"][0]
+    assert content["uri"] == "schema://content/create-from-chat"
+    assert content["mimeType"] == "application/schema+json"
+    assert "$schema" in content["text"]
+
+
+def test_resources_read_example_is_valid_json(client):
+    result = _post(
+        client,
+        _jsonrpc(
+            "resources/read", {"uri": "example://content/event-anchored-campaign"}
+        ),
+    ).json()["result"]
+    data = json.loads(result["contents"][0]["text"])
+    assert data["campaign"]["name"]
+
+
+def test_resources_read_unknown_uri(client):
+    resp = _post(client, _jsonrpc("resources/read", {"uri": "schema://content/nope"}))
+    assert resp.json()["error"]["code"] == -32602
+
+
+def test_tools_list_is_empty(client):
+    assert _post(client, _jsonrpc("tools/list")).json()["result"]["tools"] == []
+
+
+def test_endpoint_rate_limits(client, settings):
+    cache.clear()  # isolate from other tests' per-IP counts
+    settings.MCP_RATE_LIMIT = "2/m"
+    payload = _jsonrpc("tools/list")
+    assert _post(client, payload).status_code == 200
+    assert _post(client, payload).status_code == 200
+    limited = _post(client, payload)
+    assert limited.status_code == 429
+    assert limited.json()["error"]["code"] == -32000

--- a/tests/test_content_planner_schemas.py
+++ b/tests/test_content_planner_schemas.py
@@ -1,0 +1,55 @@
+"""Generated JSON Schemas + the rebuild_content_schemas management command."""
+
+import json
+
+import pytest
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from jsonschema import Draft202012Validator
+
+from content_planner import schemas
+from content_planner.models import Post
+
+
+def _channel_enum(schema):
+    return schema["properties"]["posts"]["items"]["properties"]["channel"]["enum"]
+
+
+def test_create_from_chat_channel_enum_tracks_model():
+    assert _channel_enum(schemas.build_create_from_chat_schema()) == [
+        value for value, _ in Post.CHANNEL_CHOICES
+    ]
+
+
+def test_export_schema_status_enum_tracks_model():
+    enum = schemas.build_export_schema()["properties"]["posts"]["items"]["properties"][
+        "status"
+    ]["enum"]
+    assert enum == [value for value, _ in Post.Status.choices]
+
+
+def test_committed_schemas_match_models():
+    """Mirrors the CI guard: committed files must equal freshly generated."""
+    call_command("rebuild_content_schemas", "--check")
+
+
+def test_rebuild_writes_and_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.setattr(schemas, "SCHEMA_DIR", tmp_path)
+    call_command("rebuild_content_schemas")
+    first = (tmp_path / "create_from_chat.schema.json").read_text()
+    assert (tmp_path / "export.schema.json").exists()
+    call_command("rebuild_content_schemas")
+    assert (tmp_path / "create_from_chat.schema.json").read_text() == first
+
+
+def test_rebuild_check_fails_when_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(schemas, "SCHEMA_DIR", tmp_path)  # empty: nothing written
+    with pytest.raises(CommandError):
+        call_command("rebuild_content_schemas", "--check")
+
+
+@pytest.mark.parametrize("name", ["event-anchored-campaign", "blog-and-social-series"])
+def test_examples_validate_against_schema(name):
+    validator = Draft202012Validator(schemas.build_create_from_chat_schema())
+    data = json.loads((schemas.SCHEMA_DIR / "examples" / f"{name}.json").read_text())
+    assert list(validator.iter_errors(data)) == []


### PR DESCRIPTION
## Why

When an AI assistant (or a person) produces a campaign JSON for the create-from-chat import, it has to guess the schema each time — field names, the channel enum, `scheduled_at` vs `anchor_offset_days`, which fields are ignored. This makes that contract explicit and authoritative, so the JSON is right the first time. (Schema-artifacts layer; the MCP server that *serves* these is a separate, still-deferred step.)

## What

- **`content_planner/schemas.py`** builds the create-from-chat and export JSON Schemas **from the models**, so the `channel`/`status` enums can't drift.
- **Committed artifacts** in `content_planner/schemas/`: generated `create_from_chat.schema.json` + `export.schema.json`, a `conventions.md` guide, and two worked `examples/`.
- **`parse_chat_payload` validates structure against the same schema** (via `jsonschema`) — what the agent is told == what the form accepts. Date/time values keep their precise parse errors.
- **`rebuild_content_schemas` management command** with `--check`, wired into `make lint` / CI: fails the build if a model change isn't reflected in the committed schema.
- **Human-visible:** a new **import-help page** (linked from *Import JSON*) renders the conventions + the worked examples (copyable). The only other website-visible change is that bad-import errors are now schema-derived.
- Adds the `jsonschema` dependency.

## Tests

New `test_content_planner_schemas.py` (enum tracking, idempotent regen, `--check` detects drift, examples validate, committed files in sync) + import-help render test + updated import-error fragments. **925 passing, 100% coverage**, lint clean.