### PR TITLE
Content planner: attach one asset to multiple posts from the asset form

### DIFF
--- a/content_planner/forms.py
+++ b/content_planner/forms.py
@@ -280,9 +280,6 @@ class AssetForm(forms.ModelForm):
             .select_related("campaign")
             .order_by("campaign__name", "scheduled_at", "title")
         )
-        field.label_from_instance = lambda post: (
-            f"{post.campaign.name} · {post.title} · {post.get_channel_display()}"
-        )
         if self.instance.pk:
             field.initial = self.instance.posts.all()
 

--- a/content_planner/forms.py
+++ b/content_planner/forms.py
@@ -249,7 +249,19 @@ class PostCreateForm(forms.ModelForm):
 
 
 class AssetForm(forms.ModelForm):
-    """Create / edit a board asset. Status renders as a dot+pill toggle group."""
+    """Create / edit a board asset. Status renders as a dot+pill toggle group.
+
+    ``posts`` attaches this asset to any number of the board's posts at once —
+    the reverse of the post form's asset picker, so one asset can be put on
+    several posts from one place.
+    """
+
+    posts = forms.ModelMultipleChoiceField(
+        queryset=Post.objects.none(),
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
+        label="Attach to posts",
+    )
 
     class Meta:
         model = Asset
@@ -259,3 +271,25 @@ class AssetForm(forms.ModelForm):
             "caption": forms.Textarea(attrs={"rows": 2}),
             "notes": forms.Textarea(attrs={"rows": 2}),
         }
+
+    def __init__(self, *args, board, **kwargs):
+        super().__init__(*args, **kwargs)
+        field = self.fields["posts"]
+        field.queryset = (
+            Post.objects.filter(campaign__board=board)
+            .select_related("campaign")
+            .order_by("campaign__name", "scheduled_at", "title")
+        )
+        field.label_from_instance = lambda post: (
+            f"{post.campaign.name} · {post.title} · {post.get_channel_display()}"
+        )
+        if self.instance.pk:
+            field.initial = self.instance.posts.all()
+
+    def save_posts(self, asset):
+        """Set the asset's post attachments from the cleaned ``posts`` field.
+
+        ``posts`` is the reverse side of ``Post.assets``, so ModelForm won't
+        persist it automatically; the views call this once the asset has a pk.
+        """
+        asset.posts.set(self.cleaned_data["posts"])

--- a/content_planner/templates/content_planner/asset_form.html
+++ b/content_planner/templates/content_planner/asset_form.html
@@ -45,6 +45,17 @@
         {% bootstrap_field form.source_url %}
         {% bootstrap_field form.caption %}
         {% bootstrap_field form.notes %}
+        {% if form.posts.field.queryset %}
+            <div class="mb-3">
+                <div class="fw-semibold mb-1">Attach to posts</div>
+                <div class="text-muted small mb-1">
+                    Put this asset on any of the board's posts at once.
+                </div>
+                <div class="border rounded p-2" style="max-height: 18rem; overflow: auto">
+                    {% bootstrap_field form.posts show_label=False wrapper_class="" %}
+                </div>
+            </div>
+        {% endif %}
         <div class="d-flex justify-content-between">
             <button type="submit" class="btn btn-primary">
                 Save

--- a/content_planner/templates/content_planner/asset_form.html
+++ b/content_planner/templates/content_planner/asset_form.html
@@ -36,23 +36,99 @@
             Please fix the errors highlighted below.
         </div>
     {% endif %}
-    <form method="post" enctype="multipart/form-data" style="max-width: 720px">
+    <form method="post" enctype="multipart/form-data">
         {% csrf_token %}
-        {% bootstrap_field form.name %}
-        {% bootstrap_field form.kind %}
+        <div class="row">
+            <div class="col-md-8">
+                {% bootstrap_field form.name %}
+            </div>
+            <div class="col-md-4">
+                {% bootstrap_field form.kind %}
+            </div>
+        </div>
         {% include "content_planner/_status_picker.html" with field=form.status %}
-        {% bootstrap_field form.file %}
-        {% bootstrap_field form.source_url %}
+        <div class="row">
+            <div class="{% if asset.media_url %}col-md-7{% else %}col-12{% endif %}">
+                {% bootstrap_field form.file %}
+                {% bootstrap_field form.source_url %}
+            </div>
+            {% if asset.media_url %}
+                <div class="col-md-5">
+                    <div class="fw-semibold mb-1">Current file</div>
+                    {% if asset.is_image %}
+                        <a href="{{ asset.media_url }}"
+                           rel="noopener"
+                           target="_blank"
+                           data-lightbox="{{ asset.media_url }}"
+                           data-lightbox-title="{{ asset.name }}">
+                            <img class="sc-asset-thumb"
+                                 width="96"
+                                 height="96"
+                                 src="{{ asset.media_url }}"
+                                 alt="{{ asset.name }}">
+                        </a>
+                    {% elif asset.is_video %}
+                        <a href="{{ asset.media_url }}"
+                           rel="noopener"
+                           target="_blank"
+                           data-lightbox="{{ asset.media_url }}"
+                           data-lightbox-title="{{ asset.name }}"
+                           data-lightbox-type="video">
+                            <video class="sc-asset-thumb"
+                                   width="96"
+                                   height="96"
+                                   src="{{ asset.media_url }}#t=0.1"
+                                   muted
+                                   preload="metadata">
+                            </video>
+                        </a>
+                    {% else %}
+                        <a href="{{ asset.media_url }}" rel="noopener" target="_blank">{{ asset.media_url }} ↗</a>
+                    {% endif %}
+                </div>
+            {% endif %}
+        </div>
         {% bootstrap_field form.caption %}
         {% bootstrap_field form.notes %}
         {% if form.posts.field.queryset %}
             <div class="mb-3">
                 <div class="fw-semibold mb-1">Attach to posts</div>
                 <div class="text-muted small mb-1">
-                    Put this asset on any of the board's posts at once.
+                    Put this asset on any of the board's posts. Filter to narrow a long list.
                 </div>
-                <div class="border rounded p-2" style="max-height: 18rem; overflow: auto">
-                    {% bootstrap_field form.posts show_label=False wrapper_class="" %}
+                <input type="search"
+                       class="form-control form-control-sm mb-2"
+                       placeholder="Filter by campaign, title, or channel…"
+                       oninput="scFilterAttachPosts(this)"
+                       aria-label="Filter posts">
+                {% if form.posts.errors %}
+                    <div class="text-danger small mb-1">{{ form.posts.errors }}</div>
+                {% endif %}
+                <div class="border rounded p-2" style="max-height: 22rem; overflow: auto">
+                    {% regroup form.posts.field.queryset by campaign as campaign_groups %}
+                    {% for group in campaign_groups %}
+                        <div data-attach-group>
+                            <div class="fw-semibold small text-muted mt-2">{{ group.grouper.name }}</div>
+                            {% for post in group.list %}
+                                <div class="form-check"
+                                     data-attach-row
+                                     data-search="{{ group.grouper.name|lower }} {{ post.title|lower }} {{ post.get_channel_display|lower }}">
+                                    <input class="form-check-input"
+                                           type="checkbox"
+                                           name="posts"
+                                           value="{{ post.pk }}"
+                                           id="attach-post-{{ post.pk }}"
+                                           {% if post.pk in attached_post_ids %}checked{% endif %}>
+                                    <label class="form-check-label" for="attach-post-{{ post.pk }}">
+                                        {{ post.title }}
+                                        <span class="text-muted">· {{ post.get_channel_display }}
+                                            {% if post.scheduled_at %} · {{ post.scheduled_at|date:"M j" }}{% endif %}
+                                        </span>
+                                    </label>
+                                </div>
+                            {% endfor %}
+                        </div>
+                    {% endfor %}
                 </div>
             </div>
         {% endif %}
@@ -64,4 +140,18 @@
                href="{% url 'content_planner:asset_list' board.slug %}">Cancel</a>
         </div>
     </form>
+    <script>
+      function scFilterAttachPosts(input) {
+        var q = input.value.trim().toLowerCase();
+        document.querySelectorAll('[data-attach-group]').forEach(function (group) {
+          var anyVisible = false;
+          group.querySelectorAll('[data-attach-row]').forEach(function (row) {
+            var match = !q || row.dataset.search.indexOf(q) !== -1;
+            row.style.display = match ? '' : 'none';
+            if (match) anyVisible = true;
+          });
+          group.style.display = anyVisible ? '' : 'none';
+        });
+      }
+    </script>
 {% endblock content %}

--- a/content_planner/views.py
+++ b/content_planner/views.py
@@ -442,16 +442,17 @@ def asset_list(request, board):
 @require_http_methods(["GET", "POST"])
 def asset_create(request, board):
     if request.method == "POST":
-        form = AssetForm(request.POST, request.FILES)
+        form = AssetForm(request.POST, request.FILES, board=board)
         if form.is_valid():
             check_quota(request.user, "assets", board.assets.count())
             asset = form.save(commit=False)
             asset.board = board
             asset.save()
+            form.save_posts(asset)
             messages.success(request, f"Added asset '{asset.name}'.")
             return redirect("content_planner:asset_list", board_slug=board.slug)
     else:
-        form = AssetForm()
+        form = AssetForm(board=board)
     return render(
         request,
         "content_planner/asset_form.html",
@@ -464,13 +465,14 @@ def asset_create(request, board):
 def asset_edit(request, board, pk):
     asset = get_object_or_404(Asset, board=board, pk=pk)
     if request.method == "POST":
-        form = AssetForm(request.POST, request.FILES, instance=asset)
+        form = AssetForm(request.POST, request.FILES, instance=asset, board=board)
         if form.is_valid():
-            form.save()
+            asset = form.save()
+            form.save_posts(asset)
             messages.success(request, "Asset updated.")
             return redirect("content_planner:asset_list", board_slug=board.slug)
     else:
-        form = AssetForm(instance=asset)
+        form = AssetForm(instance=asset, board=board)
     return render(
         request,
         "content_planner/asset_form.html",

--- a/content_planner/views.py
+++ b/content_planner/views.py
@@ -438,6 +438,13 @@ def asset_list(request, board):
     )
 
 
+def _attached_post_ids(form):
+    """Post ids checked in the asset form's picker — the asset's current posts
+    on GET, or the submitted selection when re-rendering after a validation
+    error, so the picker keeps its state either way."""
+    return {int(getattr(value, "pk", value)) for value in form["posts"].value() or []}
+
+
 @board_required
 @require_http_methods(["GET", "POST"])
 def asset_create(request, board):
@@ -456,7 +463,12 @@ def asset_create(request, board):
     return render(
         request,
         "content_planner/asset_form.html",
-        {"board": board, "form": form, "is_create": True},
+        {
+            "board": board,
+            "form": form,
+            "is_create": True,
+            "attached_post_ids": _attached_post_ids(form),
+        },
     )
 
 
@@ -476,7 +488,13 @@ def asset_edit(request, board, pk):
     return render(
         request,
         "content_planner/asset_form.html",
-        {"board": board, "form": form, "asset": asset, "is_create": False},
+        {
+            "board": board,
+            "form": form,
+            "asset": asset,
+            "is_create": False,
+            "attached_post_ids": _attached_post_ids(form),
+        },
     )
 
 

--- a/tests/test_content_planner_assets.py
+++ b/tests/test_content_planner_assets.py
@@ -6,7 +6,7 @@ from django.contrib.auth.models import Permission
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.urls import reverse
 
-from content_planner.forms import PostForm
+from content_planner.forms import AssetForm, PostForm
 from content_planner.models import Asset, Campaign, ContentBoard, Post
 
 User = get_user_model()
@@ -177,6 +177,76 @@ def test_post_picker_queryset_excludes_archived(board):
     form = PostForm(campaign=campaign)
     assert "assets" in form.fields
     assert not form.fields["assets"].queryset.exists()
+
+
+# -------------------------------------------- asset -> posts attach picker
+
+
+def test_asset_form_scopes_posts_to_board(board, user):
+    other = ContentBoard.objects.create(name="Other", slug="other2", owner=user)
+    mine = Post.objects.create(
+        campaign=Campaign.objects.create(board=board, name="C"),
+        title="Mine",
+        channel="blog",
+    )
+    theirs = Post.objects.create(
+        campaign=Campaign.objects.create(board=other, name="D"),
+        title="Theirs",
+        channel="blog",
+    )
+    queryset = AssetForm(board=board).fields["posts"].queryset
+    assert mine in queryset
+    assert theirs not in queryset
+
+
+def test_asset_create_attaches_posts(auth_client, board):
+    campaign = Campaign.objects.create(board=board, name="C")
+    post = Post.objects.create(campaign=campaign, title="P", channel="blog")
+    resp = auth_client.post(
+        _url("asset_create", board),
+        {
+            "name": "Hero",
+            "kind": "image",
+            "status": "drafting",
+            "source_url": "",
+            "caption": "",
+            "notes": "",
+            "posts": [post.pk],
+        },
+    )
+    assert resp.status_code == 302
+    assert list(Asset.objects.get(name="Hero").posts.all()) == [post]
+
+
+def test_asset_edit_sets_and_prechecks_posts(auth_client, board):
+    campaign = Campaign.objects.create(board=board, name="Campaign C")
+    p1 = Post.objects.create(campaign=campaign, title="P1", channel="blog")
+    p2 = Post.objects.create(campaign=campaign, title="P2", channel="mastodon")
+    asset = Asset.objects.create(board=board, name="Hero", status="ready")
+    asset.posts.add(p1)
+
+    # GET pre-checks the currently-attached post and labels by campaign.
+    get = auth_client.get(_url("asset_edit", board, pk=asset.pk))
+    content = get.content.decode()
+    assert "Attach to posts" in content
+    assert "Campaign C · P1 · Blog" in content  # label_from_instance
+    assert p1 in get.context["form"].fields["posts"].initial  # pre-checked
+
+    # POST swaps the attachment from p1 to p2.
+    resp = auth_client.post(
+        _url("asset_edit", board, pk=asset.pk),
+        {
+            "name": "Hero",
+            "kind": "image",
+            "status": "ready",
+            "source_url": "",
+            "caption": "",
+            "notes": "",
+            "posts": [p2.pk],
+        },
+    )
+    assert resp.status_code == 302
+    assert set(asset.posts.all()) == {p2}
 
 
 # ----------------------------------------------- post-page picker + upload

--- a/tests/test_content_planner_assets.py
+++ b/tests/test_content_planner_assets.py
@@ -121,6 +121,16 @@ def test_asset_edit_get(auth_client, board):
     assert auth_client.get(_url("asset_edit", board, pk=asset.pk)).status_code == 200
 
 
+def test_asset_edit_shows_current_file_preview(auth_client, board, tmp_path, settings):
+    settings.MEDIA_ROOT = str(tmp_path)
+    asset = Asset.objects.create(
+        board=board, name="Hero", file=SimpleUploadedFile("h.png", b"x")
+    )
+    content = auth_client.get(_url("asset_edit", board, pk=asset.pk)).content
+    assert b"Current file" in content
+    assert b"data-lightbox=" in content  # preview opens in the lightbox
+
+
 def test_asset_edit_post(auth_client, board):
     asset = Asset.objects.create(board=board, name="Before", status="drafting")
     resp = auth_client.post(
@@ -225,12 +235,13 @@ def test_asset_edit_sets_and_prechecks_posts(auth_client, board):
     asset = Asset.objects.create(board=board, name="Hero", status="ready")
     asset.posts.add(p1)
 
-    # GET pre-checks the currently-attached post and labels by campaign.
+    # GET groups posts by campaign, offers a filter, and pre-checks p1.
     get = auth_client.get(_url("asset_edit", board, pk=asset.pk))
     content = get.content.decode()
     assert "Attach to posts" in content
-    assert "Campaign C · P1 · Blog" in content  # label_from_instance
-    assert p1 in get.context["form"].fields["posts"].initial  # pre-checked
+    assert "Campaign C" in content  # campaign group header
+    assert "data-search=" in content  # live filter wiring
+    assert get.context["attached_post_ids"] == {p1.pk}  # pre-checked
 
     # POST swaps the attachment from p1 to p2.
     resp = auth_client.post(


### PR DESCRIPTION
## Why

You could only attach assets **from the post side** (each post's asset picker), so putting one image on several posts meant editing each post. This adds the reverse, from the asset's own form.

## What

- `AssetForm` gains a board-scoped **`posts`** field — a checkbox list of the board's posts (labelled `Campaign · Title · channel`, ordered by campaign), pre-checked with the asset's current attachments. `save_posts()` writes the reverse `Post.assets` M2M after the asset has a pk.
- Wired into asset **create** and **edit** (both pass `board`).
- The asset form shows a scrollable "Attach to posts" picker, hidden when the board has no posts yet.

So from one asset's edit page you tick every post it belongs to — one asset onto many posts in one place. (Natural next step if wanted: a real asset *detail* page that also shows where it's used.)

## Tests

Board-scoping (other boards' posts excluded), attach-on-create, and edit (pre-check + swap attachments). Full suite green at **100% coverage** on Django 6.0.6; lint clean.