### PR TITLE
Content planner: wrap full post titles in the schedule calendar

### DIFF
--- a/content_planner/templates/content_planner/schedule.html
+++ b/content_planner/templates/content_planner/schedule.html
@@ -38,7 +38,7 @@
                                     {% endif %}
                                 </div>
                                 {% for post in cell.posts %}
-                                    <div class="text-truncate">
+                                    <div class="text-break small lh-sm mb-1">
                                         <span class="sc-status-dot sc-st-{{ post.status }}"
                                               title="{{ post.get_status_display }}"></span>
                                         <a class="small{% if post.is_overdue %} text-danger fw-semibold{% endif %}"


### PR DESCRIPTION
## Problem

In the month schedule, each post used `text-truncate`, so in the 1/7-page-wide day cells the title was cut to ~10 characters — effectively unreadable. (A hover tooltip existed, but that's not enough.)

## Fix

Replace `text-truncate` with `text-break small lh-sm` so the **full title wraps** across multiple lines within the cell (long words break too); the table cell grows to fit. The status dot, time, overdue styling, and `title=` tooltip are unchanged.

If busy days get too tall, a 2-line clamp is a one-line follow-up.

Template-only; full suite green at 100% coverage, lint clean.