### PR TITLE
Surveys: fix unreadable pages when the site is toggled to dark

### DIFF
--- a/surveys/templates/surveys/_force_light.html
+++ b/surveys/templates/surveys/_force_light.html
@@ -1,10 +1,13 @@
 {% comment %}
 Surveys CSS is designed for light mode only — until dark variants land,
-force-light the page so prefers-color-scheme:dark doesn't break legibility.
-The brand stylesheet treats :root.sc-light as opt-out of its dark media query.
-data-bs-theme="light" pins Bootstrap 5.3+'s own theming.
+force-light the page so neither prefers-color-scheme:dark nor an explicit
+site dark-mode toggle breaks legibility. We must REMOVE sc-dark (the toggle
+adds it earlier in <head>, and the brand stylesheet's .sc-dark rules apply on
+the class alone), not just add sc-light. data-bs-theme="light" pins
+Bootstrap 5.3+'s own theming.
 {% endcomment %}
 <script>
+    document.documentElement.classList.remove('sc-dark');
     document.documentElement.classList.add('sc-light');
     document.documentElement.setAttribute('data-bs-theme', 'light');
 </script>


### PR DESCRIPTION
## Problem

With the site theme toggled to **dark**, surveys pages (results, builder, theme detail, …) became unreadable — survey title, the big stat numbers, the 1–5 rating bars, etc.

## Root cause

The surveys app is **light-only by design** ("until dark variants land") and every owner page pulls in `_force_light` (directly or via `_ui`). But `_force_light` only **added** `.sc-light` — it never **removed** `.sc-dark`. The site dark toggle adds `.sc-dark` earlier in `<head>`, and the brand stylesheet's `.sc-dark { … }` rules apply on the class alone, so the page still went dark on top of its hard-coded light colors.

## Fix

One line: `_force_light` now also `document.documentElement.classList.remove('sc-dark')`. Every light-only survey page renders correctly (light, legible) regardless of the site's dark toggle or OS preference. No per-page recolouring needed.

(Truly dark-theming the surveys app is a separate, larger effort — each page's custom CSS would need dark variants.)

Template-only; full suite green at 100% coverage, lint clean.