### PR TITLE
Make dev host ports overridable (run alongside other projects)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -3,7 +3,10 @@ services:
     image: postgres:16
     restart: always
     ports:
-      - "5433:5432"
+      # Host port is overridable (e.g. via .env) so this can run alongside
+      # another project that already publishes 5433. The app connects over the
+      # compose network on the internal 5432, so this only affects host access.
+      - "${SECRETCODES_POSTGRES_PORT:-5433}:5432"
     environment:
       POSTGRES_USER: secretcodes
       POSTGRES_PASSWORD: secretcodes
@@ -20,7 +23,7 @@ services:
   redis:
     image: redis:7-bullseye
     ports:
-      - "6379:6379"
+      - "${SECRETCODES_REDIS_PORT:-6379}:6379"
     healthcheck:
      test: ["CMD", "redis-cli","ping"]
      interval: 1s
@@ -34,7 +37,7 @@ services:
       - .:/code
       - ./media:/code/media
     ports:
-      - "8000:8000"
+      - "${SECRETCODES_WEB_PORT:-8000}:8000"
     environment:
       DEBUG: True
       DJANGO_ALLOWED_HOSTS: localhost,127.0.0.1,[::1]


### PR DESCRIPTION
## Why

Running secretcodes and another local project (e.g. pyladiescon-portal) at the same time fails: both publish Postgres on host `5433`, Redis on `6379`, and web on `8000`, so whichever starts second can't bind — and if the other project's containers come up mid-test, they drop secretcodes' DB connection and cascade `OperationalError`s through the suite.

## What

The three host-published ports are now env-overridable, defaulting to today's values:

```yaml
postgres: "${SECRETCODES_POSTGRES_PORT:-5433}:5432"
redis:    "${SECRETCODES_REDIS_PORT:-6379}:6379"
web:      "${SECRETCODES_WEB_PORT:-8000}:8000"
```

The app always connects over the compose network on the **internal** `5432`/`6379`, so this only changes host access — no app, settings, or CI change, and defaults are unchanged.

## Usage

Add to your local (gitignored) `.env`:

```
SECRETCODES_POSTGRES_PORT=5434
SECRETCODES_REDIS_PORT=6380
SECRETCODES_WEB_PORT=8001
```

`docker compose` auto-reads `.env`, so `make`, `docker compose up`, etc. all publish on the new ports and run cleanly beside the other project. (maildev's 1080/1025 can be given the same treatment if those ever clash.)