### PR TITLE
Make maildev host ports overridable (finish the run-alongside set)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -71,8 +71,11 @@ services:
   maildev:
     image: maildev/maildev:2.2.1
     ports:
-      - "1080:1080"
-      - "1025:1025"
+      # Host ports overridable (e.g. via .env) to run beside another project's
+      # maildev. The web service reaches maildev over the compose network on the
+      # internal 1025, so these only affect host access.
+      - "${SECRETCODES_MAILDEV_WEB_PORT:-1080}:1080"
+      - "${SECRETCODES_MAILDEV_SMTP_PORT:-1025}:1025"
 
 volumes:
   pgdata:


### PR DESCRIPTION
Follow-up to #107. `make serve` brings up **maildev** too, whose `1080`/`1025` host ports were still hardcoded and clashed with another project's maildev (`Bind for 0.0.0.0:1025 failed: port is already allocated`).

Now overridable, defaults unchanged:

```yaml
maildev:
  ports:
    - "${SECRETCODES_MAILDEV_WEB_PORT:-1080}:1080"
    - "${SECRETCODES_MAILDEV_SMTP_PORT:-1025}:1025"
```

The web service talks to `maildev:1025` over the compose network (internal port), so this only moves host access. Add to your local `.env`:

```
SECRETCODES_MAILDEV_WEB_PORT=1081
SECRETCODES_MAILDEV_SMTP_PORT=1026
```

Verified: defaults resolve to 1080/1025, overrides to 1081/1026, compose valid.