### PR TITLE
Landing: add Content planner tile; trim navbar for general visitors

### DIFF
--- a/secretcodes/templates/base.html
+++ b/secretcodes/templates/base.html
@@ -182,21 +182,30 @@
                                     {% endif %}
                                 </ul>
                             </li>
-                            <li class="nav-item">
-                                <a class="nav-link{% if ns == 'expenses' %} active{% endif %}"
-                                   {% if ns == 'expenses' %}aria-current="page"{% endif %}
-                                   href="{% url 'expenses:event_list' %}">Expenses</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link{% if ns == 'surveys' %} active{% endif %}"
-                                   {% if ns == 'surveys' %}aria-current="page"{% endif %}
-                                   href="{% url 'surveys:dashboard' %}">Surveys</a>
-                            </li>
-                            <li class="nav-item">
-                                <a class="nav-link{% if ns == 'content_planner' %} active{% endif %}"
-                                   {% if ns == 'content_planner' %}aria-current="page"{% endif %}
-                                   href="{% url 'content_planner:index' %}">Content</a>
-                            </li>
+                            {% comment %}Personal / invite-only apps — only shown to
+                            users who can actually use them, so the navbar stays
+                            relevant for general visitors.{% endcomment %}
+                            {% if perms.expenses.access_expenses %}
+                                <li class="nav-item">
+                                    <a class="nav-link{% if ns == 'expenses' %} active{% endif %}"
+                                       {% if ns == 'expenses' %}aria-current="page"{% endif %}
+                                       href="{% url 'expenses:event_list' %}">Expenses</a>
+                                </li>
+                            {% endif %}
+                            {% if perms.surveys.access_surveys %}
+                                <li class="nav-item">
+                                    <a class="nav-link{% if ns == 'surveys' %} active{% endif %}"
+                                       {% if ns == 'surveys' %}aria-current="page"{% endif %}
+                                       href="{% url 'surveys:dashboard' %}">Surveys</a>
+                                </li>
+                            {% endif %}
+                            {% if perms.content_planner.access_content_planner %}
+                                <li class="nav-item">
+                                    <a class="nav-link{% if ns == 'content_planner' %} active{% endif %}"
+                                       {% if ns == 'content_planner' %}aria-current="page"{% endif %}
+                                       href="{% url 'content_planner:index' %}">Content</a>
+                                </li>
+                            {% endif %}
                         </ul>
                     {% endwith %}
                     <button type="button"

--- a/secretcodes/templates/main.html
+++ b/secretcodes/templates/main.html
@@ -179,11 +179,28 @@
                 </div>
             </a>
         </div>
+        <div class="col-md-4">
+            <a href="{% url 'content_planner:index' %}" class="sc-card sc-tile">
+                <div class="sc-eyebrow">
+                    <span class="sc-num">06</span>Planning
+                </div>
+                <h4 class="sc-display sc-tile-title">
+                    Content planner
+                </h4>
+                <p class="sc-muted sc-tile-body">
+                    Plan blog series and social posts across channels — schedule,
+                    assets, and status in one place. Invite-only.
+                </p>
+                <div class="sc-arrow">
+                    open →
+                </div>
+            </a>
+        </div>
         {% if perms.qrcode_manager.create_slug_qrcode %}
             <div class="col-md-4">
                 <a href="{% url 'qrcode_slug_generator' %}" class="sc-card sc-tile">
                     <div class="sc-eyebrow">
-                        <span class="sc-num">06</span>Utility
+                        <span class="sc-num">07</span>Utility
                     </div>
                     <h4 class="sc-display sc-tile-title">
                         QR + slug


### PR DESCRIPTION
## What

**Landing (`main.html`)** — adds a **Content planner** tile (`06`, "Planning") to the app showcase, presented like the existing Expenses/Surveys tiles. QR + slug shifts to `07` (still owner-gated).

**Navbar (`base.html`)** — the main nav showed **Expenses, Surveys, Content** to everyone, but those are invite/owner-only, so general visitors saw links they can't use. Each is now gated behind its access permission:

| Link | Gate |
|---|---|
| Expenses | `perms.expenses.access_expenses` |
| Surveys | `perms.surveys.access_surveys` |
| Content | `perms.content_planner.access_content_planner` |

So a general visitor's navbar is just **Home + Tools (When am I free?, For agents) + QR** — the genuinely public stuff — while the owner still sees everything. (QR + slug was already perm-gated.)

Full suite green at 100% coverage, lint clean.