### PR TITLE
Azure migration: container + Terraform + deploy pipeline (validated in prod)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,49 @@
+# Keep the image small and secret-free. COPY . in the Dockerfile would
+# otherwise bake all of this into a layer (and push it to the registry).
+
+# --- Secrets: must never enter an image layer ---
+.env
+.env.*
+client_secret_*.json
+
+# --- Virtualenv / deps (image installs its own) ---
+venv/
+.venv/
+node_modules/
+
+# --- VCS / CI / editor ---
+.git/
+.gitignore
+.github/
+.idea/
+.vscode/
+.DS_Store
+
+# --- Python caches ---
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.coverage
+htmlcov/
+
+# --- Local DBs and runtime dirs (regenerated / live elsewhere in prod) ---
+*.sqlite3
+staticroot/
+media/
+.state/
+
+# --- Docs site build + infra (not part of the app runtime) ---
+site/
+docs/
+infra/
+mkdocs.yml
+
+# --- Misc dev artifacts not needed at runtime ---
+linterr.txt
+comments_*.csv
+tryout.py
+youtube_api.py
+*-design.md
+*-ideas.md
+brand-kit/
+handoff/

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,53 @@
+name: Deploy app to Azure App Service
+
+on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "mkdocs.yml"
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+
+jobs:
+  # ---- PORTABLE HALF: build + push. Unchanged when you switch hosts. ----
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      image: ${{ steps.build.outputs.image }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push
+        id: build
+        run: |
+          IMG="${{ env.IMAGE }}:${{ github.sha }}"
+          docker build -t "$IMG" -t "${{ env.IMAGE }}:latest" .
+          docker push "$IMG"
+          docker push "${{ env.IMAGE }}:latest"
+          echo "image=$IMG" >> "$GITHUB_OUTPUT"
+
+  # ---- PROVIDER-SPECIFIC HALF: the only block you swap to leave Azure. ----
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Log in to Azure
+        uses: azure/login@v2
+        with:
+          creds: ${{ secrets.AZURE_CREDENTIALS }}
+      - name: Deploy image to App Service
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: secretcodes-web
+          images: ${{ needs.build-and-push.outputs.image }}

--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,19 @@ media/
 # Build state
 .state/
 
+# Terraform — never commit state or filled-in vars (the *.example IS committed)
+infra/terraform/terraform.tfvars
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl
+
+# MkDocs build output
+site/
+
+# Database dumps (migration artifacts)
+*.dump
+
 # Claude workspace instructions (personal)
 CLAUDE.md
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -45,10 +45,24 @@ RUN  chown -R nobody /usr/local/lib/python3.13/site-packages
 
 COPY . /code/
 
+# collectstatic only needs settings to import — it never touches real data.
+# DEBUG=1 here (build-time only, NOT persisted into the image) makes settings.py
+# derive a throwaway encryption key from SECRET_KEY, so no real FERNET_KEY is
+# embedded. The real key is injected at runtime as an env var by the host.
 RUN \
+    DEBUG=1 \
     DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,[::1] \
-    DJANGO_SECRET_KEY=icecreamtaco \
+    SECRET_KEY=build-time-only \
     DATABASE_URL=postgres://localhost:5432/db \
     DJANGO_SETTINGS_MODULE=secretcodes.settings \
     python manage.py collectstatic --noinput
+
+# Portable boot contract: the image starts itself (migrate + collectstatic +
+# gunicorn) the same way on Azure App Service, Cloud Run, Fly, DO, or locally —
+# no host-specific Procfile required. The Heroku Procfile is kept as-is so
+# Heroku keeps working unchanged.
+EXPOSE 8000
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]
 

--- a/docs/deployment/azure.md
+++ b/docs/deployment/azure.md
@@ -98,6 +98,19 @@ These are real failures from the first deployment, with their fixes.
     `WEBSITES_CONTAINER_START_TIME_LIMIT` (set to `1800`) buys time, but a
     smaller `python:3.13-slim` image is the durable fix.
 
+    `ContainerTimeout` is **misleading** — App Service reports it for a fast boot
+    *crash* too, not just real slowness. `az webapp log tail` is dominated by
+    platform (`ContainerStatus`) and Kudu (`/opt/Kudu`, port 8181) noise, which
+    is **not** your app. To see the container's own stdout (the real traceback),
+    download the logs and read `*_default_docker.log`:
+    ```bash
+    az webapp log download -n secretcodes-web -g secretcodes-rg --log-file /tmp/azlogs.zip
+    unzip -o /tmp/azlogs.zip -d /tmp/azlogs
+    tail -n 80 /tmp/azlogs/LogFiles/*default_docker.log
+    ```
+    A `dj_database_url.ParseError` at settings import, for example, surfaces here
+    (see [Terraform → URL-encode the DB password](terraform.md#gotchas-worth-knowing)).
+
 !!! note "Run docker/tofu from the right directory"
     `docker build` runs from the **repo root** (it needs the `Dockerfile` and the
     full project as build context). `tofu` runs from **`infra/terraform/`**.

--- a/docs/deployment/migration.md
+++ b/docs/deployment/migration.md
@@ -66,6 +66,17 @@ docker push ghcr.io/your-gh-user/secretcodes:latest
     this, it only bites manual local builds. See
     [Azure → Gotchas](azure.md#known-gotchas-read-before-a-manual-deploy).
 
+!!! warning "Build from *current* code, not a stale `:latest`"
+    A resumed migration may already have an old `:latest` in GHCR from an earlier
+    attempt. Build fresh from the current branch or App Service serves old code
+    (routes/apps that didn't exist yet 404). After pushing, `az webapp restart`;
+    if it still serves the old layer, force a pull:
+    ```bash
+    az webapp config container set -n secretcodes-web -g secretcodes-rg \
+      --docker-custom-image-name ghcr.io/<user>/secretcodes:latest \
+      --docker-registry-server-url https://ghcr.io
+    ```
+
 ### 4. Provision Azure
 `tofu apply` (see [Terraform](terraform.md)). Grab the target URL (mind the
 trailing-`%` trap above):
@@ -107,7 +118,10 @@ az container create -g $RG --name pgmigrate --image postgres:17 \
   --secure-environment-variables HEROKU_URL="$HEROKU_URL" AZURE_URL="$AZURE_URL"
 
 az container exec -g $RG --name pgmigrate --exec-command "/bin/bash"
-# --- inside the container ---
+# --- inside the container: the exec shell does NOT inherit the secure env, so
+# --- set the URLs by hand (single-quoted; verify each starts with postgres://)
+export AZURE_URL='postgres://...'      # paste from the laptop
+export HEROKU_URL='postgres://...'
 psql "$AZURE_URL" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
 pg_dump "$HEROKU_URL" -Fc --no-owner --no-acl \
   | pg_restore --no-owner --no-acl --no-privileges -d "$AZURE_URL"
@@ -119,6 +133,21 @@ az webapp restart -n secretcodes-web -g $RG
 ```
 Match the `postgres:NN` tag to the Heroku major version. Cloud Shell's bundled
 client is often too old to dump a current server, this container sidesteps that.
+
+!!! danger "`az container exec` does **not** inherit `--secure-environment-variables`"
+    The interactive shell starts without the container's secure env, so
+    `$AZURE_URL`/`$HEROKU_URL` are empty and `psql` silently falls back to a local
+    socket (`/var/run/postgresql/.s.PGSQL.5432 ... No such file or directory`).
+    Set them inside the container by hand. Two traps when you do:
+
+    - **A failed `tofu output` gets captured as the value.** `AZURE_URL=$(tofu
+      output -raw database_url)` run in the wrong directory / without env loaded
+      captures the *error text* (you'll see box-drawing chars `╷ │`, length ~530).
+      `echo "$AZURE_URL"` and confirm it starts with `postgres://`.
+    - **Trailing `%`.** `tofu output -raw` prints no newline, so a zsh copy appends
+      a `%`, and psql fails with `invalid percent-encoded token: "require%"`. Strip
+      it: `export AZURE_URL="${AZURE_URL%\%}"`. Single-quote the value so the
+      `%`-encoded password survives.
 
 **Method B: from a local laptop (simpler steps, brief external exposure).**
 Set `operator_ip` to the laptop's public IP (`curl -s ifconfig.me`) in
@@ -132,12 +161,44 @@ re-apply afterward** to close it. Requires a local client ≥ the Heroku version
     monitoring extension unrelated to the data, safe to ignore. (To get query
     stats on Azure, allow-list it via the server's `azure.extensions` parameter.)
 
+!!! note "Harmless restore warnings: Heroku event triggers / `_heroku` schema"
+    `pg_restore` also reports ~20 ignored errors recreating event triggers
+    (`01_configure_extension_drop`, `01_extension_before_drop`) and the `_heroku`
+    schema — Heroku's internal management objects that don't exist on (or apply
+    to) Azure. They aren't your data; `errors ignored on restore: N` means
+    everything else loaded.
+
 For a community-platform-sized DB, the window is typically **5–30 minutes**.
 
 ### 6. Verify, then cut over traffic
-Test on `https://secretcodes-web.azurewebsites.net` first. Then add the custom
-domain + cert, lower DNS TTL a day ahead, and point the domain at Azure. **Keep
-Heroku intact for a few days** as rollback before deleting anything.
+First verify on `https://secretcodes-web.azurewebsites.net` — and hit the MCP
+calendar endpoint (`POST /mcp/`, `check_availability`) to confirm the migrated
+Google token **decrypts and refreshes** (`"connected": true`); that only works
+because Azure's `FERNET_KEY` matches Heroku's. Then bind the apex and flip DNS:
+
+1. **App values:** `az webapp show -n secretcodes-web -g secretcodes-rg --query
+   customDomainVerificationId -o tsv` for the ownership ID, and the inbound IP via
+   `dig +short secretcodes-web.azurewebsites.net` (the `inboundIpAddress` query
+   often returns null).
+2. **DNS (registrar):** `TXT asuid` → the verification ID, and `A @` → the
+   inbound IP. (Lower the TTL a day ahead for a near-instant flip.)
+3. **Hostname + cert:** `az webapp config hostname add --webapp-name
+   secretcodes-web -g secretcodes-rg --hostname secretcodes.dev`, then create the
+   free managed cert **in the Portal** (Custom domains → Add binding → SNI SSL →
+   *Create App Service Managed Certificate*). The CLI `az webapp config ssl
+   create` is in preview and throws a `JSONDecodeError`. The cert can only be
+   issued *after* the A record points at Azure (Azure validates by reaching the
+   domain), so expect a brief HTTPS-pending window.
+
+!!! danger "Trust the apex host or it 500s with `DisallowedHost`"
+    The app answers on `azurewebsites.net` but Django rejects `secretcodes.dev`
+    until it's allowed. Set `custom_domain = "secretcodes.dev"` in
+    `terraform.tfvars` and `tofu apply` — that adds the apex to
+    `DJANGO_ALLOWED_HOSTS` + `CSRF_TRUSTED_ORIGINS` and sets the OAuth redirect
+    URI. (A missing host shows as a 500 here, not a 400, because the branded error
+    page itself reads the host.)
+
+**Keep Heroku intact for a few days** as rollback before deleting anything.
 
 ### 7. Automate ongoing deploys
 `deploy.yml` is already wired; from here, pushing to `main` ships automatically.

--- a/docs/deployment/migration.md
+++ b/docs/deployment/migration.md
@@ -207,6 +207,35 @@ because Azure's `FERNET_KEY` matches Heroku's. Then bind the apex and flip DNS:
 Before DNS cutover: nothing to roll back, Heroku is still live. After: flip DNS
 back (Heroku intact) and turn its maintenance off. Low TTL keeps this quick.
 
+## Decommission Heroku (once Azure has proven itself)
+
+!!! warning "Maintenance mode does **not** stop billing"
+    Dynos and add-ons keep charging while they exist, and Heroku has no true
+    "pause". Do this only after a few days of confidence, in stages from
+    "keep rollback" to "$0".
+
+**1. Stop dyno (compute) charges — keeps the rollback DB live:**
+```bash
+heroku ps:scale web=0 -a <heroku-app>      # plus worker=0 etc. if you have them
+```
+
+**2. The Postgres add-on is the main ongoing cost** (it's the rollback data).
+See what bills with `heroku addons -a <heroku-app>`, then either keep it a few
+more days, or capture a backup and remove it (rollback becomes the dump):
+```bash
+heroku pg:backups:capture  -a <heroku-app>
+heroku pg:backups:download -a <heroku-app>      # -> latest.dump, keep it safe
+heroku addons:destroy <postgres-addon-name> -a <heroku-app>
+```
+
+**3. Stop all charges** once you're sure you won't roll back:
+```bash
+heroku apps:destroy -a <heroku-app>             # irreversible; prompts for the name
+```
+
+The DigitalOcean Spaces bucket (media + this docs site) is separate and stays —
+it was never a Heroku resource.
+
 ## Leaving Azure later (same playbook, reversed)
 - **App:** point a new host at the *same* GHCR image; recreate the env vars.
 - **DB:** `pg_dump` from Azure → `pg_restore` into the new Postgres. Step 5 in

--- a/docs/deployment/terraform.md
+++ b/docs/deployment/terraform.md
@@ -62,6 +62,27 @@ terraform output -raw database_url
     Set `postgres_version` to the Heroku Postgres major version before applying,
     or the dump/restore can fail.
 
+!!! warning "`tofu init` fails on a stale `.terraform` cache"
+    If a previous run left a `.terraform/` provider cache, `tofu init` can fail
+    with `existing cached package ... does not match the content of the
+    downloaded package; does it contain local modifications?`. The cache is
+    local and regenerable, so clear it and re-init:
+    ```bash
+    rm -rf .terraform
+    tofu init
+    ```
+    If it still complains (a lock-hash mismatch rather than a cache mismatch),
+    also remove `.terraform.lock.hcl` and re-init.
+
+!!! danger "URL-encode the DB password (or the app won't boot)"
+    `main.tf` builds `DATABASE_URL` with `urlencode(var.postgres_admin_password)`.
+    This matters: modern `dj-database-url` **rejects** a `DATABASE_URL` whose
+    parts aren't percent-encoded, so a password containing `+`, `/`, or `=`
+    (exactly what `openssl rand -base64` produces) makes the container crash at
+    settings import with `dj_database_url.ParseError` — which Azure then reports
+    as the misleading `ContainerTimeout`. With `urlencode()` any password is
+    safe; without it, use a URL-safe password like `openssl rand -hex 24`.
+
 ## State and portability
 
 State is local until the backend in `providers.tf` is uncommented. Two thoughts:

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env sh
+set -e
+
+echo "==> Running migrations"
+python manage.py migrate --noinput
+
+echo "==> Collecting static files"
+python manage.py collectstatic --noinput
+
+# App Service injects PORT (set WEBSITES_PORT=8000 in app settings so the
+# platform routes correctly). Falls back to 8000 locally.
+PORT="${PORT:-8000}"
+
+echo "==> Starting gunicorn on :${PORT}"
+exec gunicorn secretcodes.wsgi:application \
+    --bind "0.0.0.0:${PORT}" \
+    --workers 3 \
+    --timeout 60 \
+    --access-logfile - \
+    --error-logfile -

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -3,7 +3,10 @@ locals {
   pg_name  = "${var.name_prefix}-pg"
 
   # sslmode=require is mandatory on Azure Postgres — and harmless everywhere else.
-  database_url = "postgres://${var.postgres_admin_user}:${var.postgres_admin_password}@${azurerm_postgresql_flexible_server.pg.fqdn}:5432/${var.postgres_db_name}?sslmode=require"
+  # urlencode the password: modern dj-database-url rejects a DATABASE_URL whose
+  # parts aren't percent-encoded, so a password containing +, /, =, etc. (e.g.
+  # from `openssl rand -base64`) would otherwise make the app fail to boot.
+  database_url = "postgres://${var.postgres_admin_user}:${urlencode(var.postgres_admin_password)}@${azurerm_postgresql_flexible_server.pg.fqdn}:5432/${var.postgres_db_name}?sslmode=require"
 
   # application_stack wants the image path + tag WITHOUT the registry host;
   # the host goes in docker_registry_url. Strip "ghcr.io/" from the full ref.

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -2,6 +2,14 @@ locals {
   app_name = "${var.name_prefix}-web"
   pg_name  = "${var.name_prefix}-pg"
 
+  # Host(s) the app answers on. With a custom apex domain bound, both the
+  # azurewebsites.net hostname and the custom domain must be trusted, or Django
+  # rejects requests to the custom domain (DisallowedHost / CSRF failures).
+  azure_host    = "${var.name_prefix}-web.azurewebsites.net"
+  public_host   = var.custom_domain != "" ? var.custom_domain : local.azure_host
+  allowed_hosts = var.custom_domain != "" ? "${local.azure_host},${var.custom_domain}" : local.azure_host
+  csrf_origins  = var.custom_domain != "" ? "https://${local.azure_host},https://${var.custom_domain}" : "https://${local.azure_host}"
+
   # sslmode=require is mandatory on Azure Postgres — and harmless everywhere else.
   # urlencode the password: modern dj-database-url rejects a DATABASE_URL whose
   # parts aren't percent-encoded, so a password containing +, /, =, etc. (e.g.
@@ -105,16 +113,16 @@ resource "azurerm_linux_web_app" "web" {
     # DEBUG must stay off in prod, which is exactly why FERNET_KEY is required.
     DEBUG = ""
     # The app reads DJANGO_ALLOWED_HOSTS (settings.py), not ALLOWED_HOSTS.
-    DJANGO_ALLOWED_HOSTS = "${local.app_name}.azurewebsites.net"
+    DJANGO_ALLOWED_HOSTS = local.allowed_hosts
     # Scheme+host trusted for CSRF (Django 4.0+). App Service terminates TLS, so
     # the browser's https:// Origin must be listed here or logins fail CSRF.
-    CSRF_TRUSTED_ORIGINS = "https://${local.app_name}.azurewebsites.net"
+    CSRF_TRUSTED_ORIGINS = local.csrf_origins
 
     # Google OAuth for availability calendar sync. Reuse the Heroku client; the
     # redirect URI must point at this host and be registered in Google Console.
     GOOGLE_CLIENT_ID          = var.google_client_id
     GOOGLE_CLIENT_SECRET      = var.google_client_secret
-    GOOGLE_OAUTH_REDIRECT_URI = "https://${local.app_name}.azurewebsites.net/availability/oauth/callback/"
+    GOOGLE_OAUTH_REDIRECT_URI = "https://${local.public_host}/availability/oauth/callback/"
 
     # settings.py only wires up the S3/Spaces storage (and the AWS_* settings the
     # QR generator reads) when USE_SPACES == "true". Without it, QR creation 500s.

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,0 +1,127 @@
+locals {
+  app_name = "${var.name_prefix}-web"
+  pg_name  = "${var.name_prefix}-pg"
+
+  # sslmode=require is mandatory on Azure Postgres — and harmless everywhere else.
+  database_url = "postgres://${var.postgres_admin_user}:${var.postgres_admin_password}@${azurerm_postgresql_flexible_server.pg.fqdn}:5432/${var.postgres_db_name}?sslmode=require"
+
+  # application_stack wants the image path + tag WITHOUT the registry host;
+  # the host goes in docker_registry_url. Strip "ghcr.io/" from the full ref.
+  docker_image_name = replace(var.image, "ghcr.io/", "")
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "${var.name_prefix}-rg"
+  location = var.location
+}
+
+# --- PostgreSQL Flexible Server (Burstable B1ms) -----------------------------
+
+resource "azurerm_postgresql_flexible_server" "pg" {
+  name                          = local.pg_name
+  resource_group_name           = azurerm_resource_group.rg.name
+  location                      = azurerm_resource_group.rg.location
+  version                       = var.postgres_version
+  administrator_login           = var.postgres_admin_user
+  administrator_password        = var.postgres_admin_password
+  sku_name                      = "B_Standard_B1ms"
+  storage_mb                    = 32768
+  public_network_access_enabled = true
+
+  lifecycle {
+    # Azure may pick/relocate the availability zone; don't fight it on re-apply.
+    ignore_changes = [zone]
+  }
+}
+
+resource "azurerm_postgresql_flexible_server_database" "db" {
+  name      = var.postgres_db_name
+  server_id = azurerm_postgresql_flexible_server.pg.id
+  charset   = "UTF8"
+  collation = "en_US.utf8"
+}
+
+# Lets other Azure services (incl. your App Service) reach the DB.
+resource "azurerm_postgresql_flexible_server_firewall_rule" "azure_services" {
+  name             = "allow-azure-services"
+  server_id        = azurerm_postgresql_flexible_server.pg.id
+  start_ip_address = "0.0.0.0"
+  end_ip_address   = "0.0.0.0"
+}
+
+# Optional: open the DB to your laptop for the one-time migration restore.
+resource "azurerm_postgresql_flexible_server_firewall_rule" "operator" {
+  count            = var.operator_ip == "" ? 0 : 1
+  name             = "operator-laptop"
+  server_id        = azurerm_postgresql_flexible_server.pg.id
+  start_ip_address = var.operator_ip
+  end_ip_address   = var.operator_ip
+}
+
+# --- Compute: App Service plan + container web app ---------------------------
+
+resource "azurerm_service_plan" "plan" {
+  name                = "${var.name_prefix}-plan"
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_resource_group.rg.location
+  os_type             = "Linux"
+  sku_name            = "B1"
+}
+
+resource "azurerm_linux_web_app" "web" {
+  name                = local.app_name
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_service_plan.plan.location
+  service_plan_id     = azurerm_service_plan.plan.id
+  https_only          = true
+
+  site_config {
+    always_on = true
+
+    application_stack {
+      docker_image_name        = local.docker_image_name
+      docker_registry_url      = "https://ghcr.io" # protocol is REQUIRED by the provider
+      docker_registry_username = var.ghcr_user
+      docker_registry_password = var.ghcr_pat
+    }
+  }
+
+  app_settings = {
+    WEBSITES_PORT = "8000"
+    # App Service kills the container if it doesn't answer the startup probe
+    # within this many seconds (default 230). A large first-pull + migrate on
+    # boot can exceed that, so raise it to the max. The durable fix is a smaller
+    # image (python:3.13-slim) + moving collectstatic to build time.
+    WEBSITES_CONTAINER_START_TIME_LIMIT = "1800"
+
+    DATABASE_URL = local.database_url
+    SECRET_KEY   = var.django_secret_key
+    FERNET_KEY   = var.fernet_key
+    # settings.py does DEBUG = bool(os.environ.get("DEBUG", 0)) — any non-empty
+    # string (incl. "0") is truthy, so an empty string is the only safe "off".
+    # DEBUG must stay off in prod, which is exactly why FERNET_KEY is required.
+    DEBUG = ""
+    # The app reads DJANGO_ALLOWED_HOSTS (settings.py), not ALLOWED_HOSTS.
+    DJANGO_ALLOWED_HOSTS = "${local.app_name}.azurewebsites.net"
+    # Scheme+host trusted for CSRF (Django 4.0+). App Service terminates TLS, so
+    # the browser's https:// Origin must be listed here or logins fail CSRF.
+    CSRF_TRUSTED_ORIGINS = "https://${local.app_name}.azurewebsites.net"
+
+    # Google OAuth for availability calendar sync. Reuse the Heroku client; the
+    # redirect URI must point at this host and be registered in Google Console.
+    GOOGLE_CLIENT_ID          = var.google_client_id
+    GOOGLE_CLIENT_SECRET      = var.google_client_secret
+    GOOGLE_OAUTH_REDIRECT_URI = "https://${local.app_name}.azurewebsites.net/availability/oauth/callback/"
+
+    # settings.py only wires up the S3/Spaces storage (and the AWS_* settings the
+    # QR generator reads) when USE_SPACES == "true". Without it, QR creation 500s.
+    USE_SPACES              = "true"
+    AWS_ACCESS_KEY_ID       = var.spaces_key
+    AWS_SECRET_ACCESS_KEY   = var.spaces_secret
+    AWS_STORAGE_BUCKET_NAME = var.spaces_bucket
+    AWS_S3_ENDPOINT_URL     = var.spaces_endpoint
+
+    # Do NOT add DOCKER_REGISTRY_SERVER_* here. The provider manages registry
+    # creds via application_stack; duplicating them causes a perpetual diff.
+  }
+}

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -1,0 +1,22 @@
+output "app_url" {
+  description = "Public URL of the web app."
+  value       = "https://${azurerm_linux_web_app.web.default_hostname}"
+}
+
+output "app_name" {
+  value = azurerm_linux_web_app.web.name
+}
+
+output "resource_group" {
+  value = azurerm_resource_group.rg.name
+}
+
+output "postgres_fqdn" {
+  value = azurerm_postgresql_flexible_server.pg.fqdn
+}
+
+output "database_url" {
+  description = "Restore target for the migration. Sensitive — contains the password. View with: terraform output -raw database_url"
+  value       = local.database_url
+  sensitive   = true
+}

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -1,0 +1,32 @@
+terraform {
+  required_version = ">= 1.5"
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 4.0"
+    }
+  }
+
+  # Remote state keeps the source of truth off your laptop. Commented out so the
+  # first `terraform init` works locally with zero setup. When ready, create a
+  # state container and uncomment. The backend is itself a portability choice:
+  # azurerm below ties state to Azure; if you'd rather keep state vendor-neutral
+  # you can use an S3-compatible backend pointed at DigitalOcean Spaces instead.
+  #
+  # backend "azurerm" {
+  #   resource_group_name  = "tfstate-rg"
+  #   storage_account_name = "secretcodestfstate"
+  #   container_name       = "tfstate"
+  #   key                  = "secretcodes.tfstate"
+  # }
+}
+
+provider "azurerm" {
+  features {}
+
+  # azurerm v4 requires the subscription explicitly. Either set it here via the
+  # variable, or (preferred — keeps it out of code) export ARM_SUBSCRIPTION_ID
+  # in your shell and leave the variable null.
+  subscription_id = var.subscription_id
+}

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -1,0 +1,25 @@
+# Copy to terraform.tfvars (which should be gitignored) and fill in.
+# SECRETS: prefer environment variables over this file. Terraform reads any
+# TF_VAR_<name> automatically, e.g.:
+#   export TF_VAR_postgres_admin_password='...'
+#   export TF_VAR_ghcr_pat='...'
+#   export TF_VAR_django_secret_key='...'
+#   export TF_VAR_fernet_key='...'     # python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'
+#   export TF_VAR_spaces_key='...' TF_VAR_spaces_secret='...'
+#   export ARM_SUBSCRIPTION_ID='...'   # so you can leave subscription_id null
+
+location         = "canadacentral"
+name_prefix      = "secretcodes"
+postgres_version = "16" # MUST match your Heroku Postgres major version
+
+image     = "ghcr.io/your-gh-user/secretcodes:latest"
+ghcr_user = "your-gh-user"
+
+postgres_db_name    = "secretcodes"
+postgres_admin_user = "scadmin"
+
+spaces_bucket   = "your-space-name"
+spaces_endpoint = "https://nyc3.digitaloceanspaces.com"
+
+# Set to your public IP for the migration restore (then blank it out after):
+operator_ip = "" # e.g. "203.0.113.7"

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -12,6 +12,12 @@ location         = "canadacentral"
 name_prefix      = "secretcodes"
 postgres_version = "16" # MUST match your Heroku Postgres major version
 
+# Apex domain bound to the app. When set, it's added to DJANGO_ALLOWED_HOSTS /
+# CSRF_TRUSTED_ORIGINS and used for the OAuth redirect URI. Leave empty to serve
+# only on <name_prefix>-web.azurewebsites.net. Bind the domain + cert in Azure
+# (see migration.md step 6) separately; this only trusts the host in the app.
+custom_domain = "" # e.g. "secretcodes.dev"
+
 image     = "ghcr.io/your-gh-user/secretcodes:latest"
 ghcr_user = "your-gh-user"
 

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -16,6 +16,12 @@ variable "name_prefix" {
   default     = "secretcodes"
 }
 
+variable "custom_domain" {
+  description = "Custom apex domain bound to the web app, e.g. secretcodes.dev. Added to DJANGO_ALLOWED_HOSTS / CSRF_TRUSTED_ORIGINS and used for the OAuth redirect URI. Empty = azurewebsites.net only."
+  type        = string
+  default     = ""
+}
+
 # --- PostgreSQL --------------------------------------------------------------
 
 variable "postgres_version" {

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -1,0 +1,115 @@
+variable "subscription_id" {
+  description = "Azure subscription ID. Leave null and export ARM_SUBSCRIPTION_ID instead."
+  type        = string
+  default     = null
+}
+
+variable "location" {
+  description = "Azure region (closest to Vancouver)."
+  type        = string
+  default     = "canadacentral"
+}
+
+variable "name_prefix" {
+  description = "Prefix for resource names. Note: web app and PG server names must be globally unique."
+  type        = string
+  default     = "secretcodes"
+}
+
+# --- PostgreSQL --------------------------------------------------------------
+
+variable "postgres_version" {
+  description = "PostgreSQL MAJOR version. MUST match your Heroku source version."
+  type        = string
+  default     = "16"
+}
+
+variable "postgres_admin_user" {
+  type    = string
+  default = "scadmin"
+}
+
+variable "postgres_admin_password" {
+  description = "Postgres admin password. Pass via TF_VAR_postgres_admin_password."
+  type        = string
+  sensitive   = true
+}
+
+variable "postgres_db_name" {
+  type    = string
+  default = "secretcodes"
+}
+
+# --- Container image ---------------------------------------------------------
+
+variable "image" {
+  description = "Full image reference incl. tag, e.g. ghcr.io/<user>/secretcodes:latest"
+  type        = string
+}
+
+variable "ghcr_user" {
+  description = "GitHub username that owns the GHCR image."
+  type        = string
+}
+
+variable "ghcr_pat" {
+  description = "GitHub PAT with read:packages. Pass via TF_VAR_ghcr_pat."
+  type        = string
+  sensitive   = true
+}
+
+# --- Django ------------------------------------------------------------------
+
+variable "django_secret_key" {
+  description = "Pass via TF_VAR_django_secret_key."
+  type        = string
+  sensitive   = true
+}
+
+variable "fernet_key" {
+  description = "Fernet key for encrypting secrets at rest. REQUIRED in production (DEBUG=0) — the app refuses to boot without it. Generate with: python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'. Pass via TF_VAR_fernet_key."
+  type        = string
+  sensitive   = true
+}
+
+# --- Google OAuth (availability calendar sync) -------------------------------
+
+variable "google_client_id" {
+  description = "Google OAuth 2.0 client ID. Reuse the Heroku value: heroku config:get GOOGLE_CLIENT_ID."
+  type        = string
+}
+
+variable "google_client_secret" {
+  description = "Google OAuth 2.0 client secret. Pass via TF_VAR_google_client_secret (reuse Heroku's)."
+  type        = string
+  sensitive   = true
+}
+
+# --- DigitalOcean Spaces (media stays here) ----------------------------------
+
+variable "spaces_key" {
+  type      = string
+  sensitive = true
+}
+
+variable "spaces_secret" {
+  type      = string
+  sensitive = true
+}
+
+variable "spaces_bucket" {
+  type = string
+}
+
+variable "spaces_endpoint" {
+  description = "e.g. https://nyc3.digitaloceanspaces.com"
+  type        = string
+}
+
+# --- Migration convenience ---------------------------------------------------
+
+variable "operator_ip" {
+  description = "Your public IP, to open the DB firewall for the one-time restore. Empty = skip."
+  type        = string
+  default     = ""
+}

--- a/secretcodes/settings.py
+++ b/secretcodes/settings.py
@@ -56,6 +56,17 @@ else:
     if ALLOWED_HOSTS:
         ALLOWED_HOSTS = ALLOWED_HOSTS.split(",")
 
+    # Behind a TLS-terminating proxy (e.g. Azure App Service), trust the
+    # forwarded scheme so Django sees the request as HTTPS. Without this the
+    # https:// Origin header fails CSRF's origin check.
+    SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+
+    # Scheme+host origins trusted for unsafe requests, comma-separated, e.g.
+    # "https://secretcodes-web.azurewebsites.net". Required since Django 4.0.
+    CSRF_TRUSTED_ORIGINS = [
+        o for o in os.environ.get("CSRF_TRUSTED_ORIGINS", "").split(",") if o
+    ]
+
 
 # Logging. Django's default only logs to console when DEBUG=True. In
 # production we want tracebacks in stderr so Heroku captures them.


### PR DESCRIPTION
Brings the Heroku → Azure migration infrastructure onto main. This was run end-to-end and **secretcodes.dev is now live on Azure** (apex + valid HTTPS, real data migrated, Google Calendar token refresh working). Merging version-controls it and turns on push-to-deploy.

## What's included
- **App container:** `Dockerfile` (self-starting, amd64), `entrypoint.sh` (migrate → collectstatic → gunicorn), `.dockerignore`.
- **Terraform** (`infra/terraform/`): resource group, Postgres Flexible Server + DB + firewall, App Service plan + Linux web app. Plus the fixes found during the cutover:
  - `urlencode()` the DB password in `DATABASE_URL` (modern dj-database-url rejects un-encoded passwords → boot crash mislabeled `ContainerTimeout`).
  - a `custom_domain` variable that adds the apex to `DJANGO_ALLOWED_HOSTS` / `CSRF_TRUSTED_ORIGINS` and the OAuth redirect URI (apex 500s with `DisallowedHost` otherwise).
- **`settings.py`:** `SECURE_PROXY_SSL_HEADER` + `CSRF_TRUSTED_ORIGINS` for running behind App Service's TLS proxy.
- **`.github/workflows/deploy.yml`:** build → GHCR → App Service on push to `main`.
- **Docs:** the migration playbook updated with every gotcha we hit (stale `.terraform` cache, URL-encode password, `ContainerTimeout` red herrings + reading the real container log, `az container exec` not inheriting secure env, captured-`tofu`-error + trailing `%`, Heroku event-trigger restore warnings, apex hostname/cert + `ALLOWED_HOSTS`).

## After merge
`deploy.yml` runs on push to `main` and deploys to the existing App Service, so set the repo secrets it needs first: **`AZURE_CREDENTIALS`** (service principal) and GHCR pull auth. Heroku stays as rollback for a few days.

Full suite was green at 100% coverage on this branch.