### PR TITLE
deploy: lowercase the GHCR image name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,10 @@ jobs:
       image: ${{ steps.build.outputs.image }}
     steps:
       - uses: actions/checkout@v4
+      # github.repository preserves owner case (Mariatta/...), but Docker/GHCR
+      # tags must be lowercase. Override IMAGE with the lowercased repo path.
+      - name: Lowercase the image name
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
       - name: Log in to GHCR
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
The first `deploy.yml` run failed at build:
```
invalid tag "ghcr.io/Mariatta/secretcodes:<sha>": repository name must be lowercase
```
`github.repository` preserves the owner's case (`Mariatta/...`), but Docker/GHCR tags must be lowercase. Override `IMAGE` with `ghcr.io/${GITHUB_REPOSITORY,,}` in a step before build/push. Merging this re-runs `deploy.yml` on `main`.