### PR TITLE
Fix greyed-out clickable list items (content vs surveys consistency)

### DIFF
--- a/secretcodes/static/brand/secret-codes.css
+++ b/secretcodes/static/brand/secret-codes.css
@@ -135,6 +135,16 @@
   }
 }
 
+/* Bootstrap styles clickable "action" list items with a muted secondary color,
+   which reads as inactive and clashes with plain lists (e.g. surveys, which are
+   static <div>s). Use the full theme text color so clickable lists (content
+   planner boards/campaigns) look as crisp and active as the static ones. */
+.list-group {
+  --bs-list-group-action-color:        var(--sc-fg);
+  --bs-list-group-action-hover-color:  var(--sc-fg);
+  --bs-list-group-action-active-color: var(--sc-fg);
+}
+
 /* 3. Base --------------------------------------------------- */
 html, body {
   background: var(--sc-bg);


### PR DESCRIPTION
The content planner's board/campaign lists looked greyed-out and inactive next to the surveys list. Cause: those lists are clickable (`list-group-item-action`), and Bootstrap styles the action variant with a muted secondary color, whereas surveys uses plain static `list-group-item` (full text color).

Fix: override `--bs-list-group-action-color` (+ hover/active) to the theme foreground (`--sc-fg`), so clickable lists render as crisp and active as static ones, in both light and dark. CSS-only.