### PR TITLE
availability: brand-map the week-grid day-status colours

### DIFF
--- a/availability/templates/availability/week_grid.html
+++ b/availability/templates/availability/week_grid.html
@@ -4,17 +4,6 @@
     Mariatta's availability · {{ block.super }}
 {% endblock head_title %}
 {% block extra_head %}
-    <style>
-        .day-grid {
-            display: grid;
-            grid-template-columns: repeat(2, 1fr);
-            gap: 0.5rem;
-            margin-bottom: 1rem;
-        }
-        @media (min-width: 768px) {
-            .day-grid { grid-template-columns: repeat(4, 1fr); }
-        }
-    </style>
 {% endblock extra_head %}
 {% block content %}
     {% timezone profile.timezone %}

--- a/secretcodes/static/brand/secret-codes.css
+++ b/secretcodes/static/brand/secret-codes.css
@@ -1138,3 +1138,24 @@ a:hover { color: var(--sc-accent); text-decoration-color: currentColor; }
 .survey-subnav .nav-link:hover,
 .survey-subnav .nav-link:focus { color: var(--sc-fg); }
 .survey-subnav .nav-link.active { color: var(--sc-bg); background-color: var(--sc-fg); }
+
+/* ============================================================
+   Availability week grid
+   Responsive 2/4-col layout, plus the day-status colours remapped from
+   Bootstrap's defaults (green / red / cyan / amber) to the brand palette.
+   Scoped to .day-grid so success/danger elsewhere (e.g. expenses balances)
+   keep their own meaning; the status cards/badges inside inherit these.
+   ============================================================ */
+.day-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  --bs-success-rgb: 46, 110, 106;  /* teal, wide open */
+  --bs-warning-rgb: 199, 154, 58;  /* gold, tight */
+  --bs-danger-rgb:  216, 76, 47;   /* signal, unlikely */
+  --bs-info-rgb:    138, 122, 184; /* lilac, off-hours */
+}
+@media (min-width: 768px) {
+  .day-grid { grid-template-columns: repeat(4, 1fr); }
+}


### PR DESCRIPTION
Follow-up to #124 (this commit missed its squash).

The availability week grid coloured its day cards with Bootstrap's default contextual classes (green `success`, red `danger`, cyan `info`, amber `warning`), which are off-brand. Remap them to the brand palette, **scoped to `.day-grid`** so `success`/`danger` elsewhere (e.g. expenses balances) keep their meaning:

- wide-open → **teal**
- tight → **gold**
- unlikely → **signal red**
- off-hours → **lilac**
- (likely-available stays navy = brand `primary`)

The cards inherit the remapped `--bs-*-rgb`, so no template class changes were needed. Also moves the layout-only inline `<style>` into `secret-codes.css`, so availability no longer carries an inline style block.

CSS + template only; coverage unchanged.