### PR TITLE
Azure: wire Mailgun SMTP into Terraform; document the missing-email gotcha

### DIFF
--- a/docs/deployment/migration.md
+++ b/docs/deployment/migration.md
@@ -206,6 +206,30 @@ because Azure's `FERNET_KEY` matches Heroku's. Then bind the apex and flip DNS:
     URI. (A missing host shows as a 500 here, not a 400, because the branded error
     page itself reads the host.)
 
+!!! danger "Heroku's Mailgun config does not migrate: set the SMTP vars in Terraform"
+    On Heroku the Mailgun addon supplied the SMTP config, so nothing in the
+    repo listed it as a required env var. Azure gets none of it, and
+    `settings.py` quietly falls back to `localhost:25`. The app then deploys
+    and serves fine, but **every email send 500s**: survey / expenses /
+    content invitations and booking notifications all die with
+    `OSError: [Errno 99] Cannot assign requested address` from
+    `django/core/mail/backends/smtp.py` (this bit prod on 2026-07-08, weeks
+    after cutover, because email is the only feature that needs it).
+
+    The fix lives in Terraform, since it owns the whole `app_settings` map
+    (anything set with `az webapp config appsettings set` is wiped on the
+    next `tofu apply`): set `mailgun_smtp_user` in `terraform.tfvars`,
+    export `TF_VAR_mailgun_smtp_password`, and `tofu apply`. The SMTP
+    credentials live in the Mailgun dashboard under Sending → Domain
+    settings → SMTP credentials; the SMTP password is **not** the API key.
+    The app restarts itself when settings change.
+
+    Verify by sending a survey invite; if it still fails, the traceback is
+    in the container console log:
+    `az webapp log tail -n secretcodes-web -g secretcodes-rg` live, or
+    `az webapp log download` and grep the
+    `LogFiles/<date>_*_containerStream.log` files for `Traceback`.
+
 **Keep Heroku intact for a few days** as rollback before deleting anything.
 
 ### 7. Automate ongoing deploys

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -124,6 +124,16 @@ resource "azurerm_linux_web_app" "web" {
     GOOGLE_CLIENT_SECRET      = var.google_client_secret
     GOOGLE_OAUTH_REDIRECT_URI = "https://${local.public_host}/availability/oauth/callback/"
 
+    # Email (Mailgun SMTP). Heroku's addon provided this implicitly; without it
+    # settings.py falls back to localhost:25 and every email send (survey /
+    # expenses / content invites, booking notifications) 500s.
+    DJANGO_EMAIL_HOST          = "smtp.mailgun.org"
+    DJANGO_EMAIL_PORT          = "587"
+    DJANGO_EMAIL_HOST_USER     = var.mailgun_smtp_user
+    DJANGO_EMAIL_HOST_PASSWORD = var.mailgun_smtp_password
+    DJANGO_EMAIL_USE_TLS       = "true"
+    DJANGO_DEFAULT_FROM_EMAIL  = var.default_from_email
+
     # settings.py only wires up the S3/Spaces storage (and the AWS_* settings the
     # QR generator reads) when USE_SPACES == "true". Without it, QR creation 500s.
     USE_SPACES              = "true"

--- a/infra/terraform/terraform.tfvars.example
+++ b/infra/terraform/terraform.tfvars.example
@@ -6,6 +6,7 @@
 #   export TF_VAR_django_secret_key='...'
 #   export TF_VAR_fernet_key='...'     # python -c 'from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())'
 #   export TF_VAR_spaces_key='...' TF_VAR_spaces_secret='...'
+#   export TF_VAR_mailgun_smtp_password='...'  # SMTP password, NOT the API key
 #   export ARM_SUBSCRIPTION_ID='...'   # so you can leave subscription_id null
 
 location         = "canadacentral"
@@ -26,6 +27,11 @@ postgres_admin_user = "scadmin"
 
 spaces_bucket   = "your-space-name"
 spaces_endpoint = "https://nyc3.digitaloceanspaces.com"
+
+# Mailgun SMTP (dashboard: Sending → Domain settings → SMTP credentials).
+# Heroku's addon set this implicitly; on Azure email 500s without it.
+mailgun_smtp_user = "postmaster@your-domain"
+# default_from_email = "You <you@your-domain>"
 
 # Set to your public IP for the migration restore (then blank it out after):
 operator_ip = "" # e.g. "203.0.113.7"

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -112,6 +112,28 @@ variable "spaces_endpoint" {
   type        = string
 }
 
+# --- Email (Mailgun SMTP) ------------------------------------------------------
+# Heroku's Mailgun addon supplied these implicitly; on Azure they must be set
+# or every email send (invites, booking notifications) 500s with
+# "OSError: [Errno 99] Cannot assign requested address" (SMTP to localhost).
+
+variable "mailgun_smtp_user" {
+  description = "Mailgun SMTP login, e.g. postmaster@mariatta.ca (dashboard: Sending → Domain settings → SMTP credentials)."
+  type        = string
+}
+
+variable "mailgun_smtp_password" {
+  description = "Mailgun SMTP password (NOT the API key). Pass via TF_VAR_mailgun_smtp_password."
+  type        = string
+  sensitive   = true
+}
+
+variable "default_from_email" {
+  description = "From address for outgoing mail."
+  type        = string
+  default     = "Mariatta <mariatta@mariatta.ca>"
+}
+
 # --- Migration convenience ---------------------------------------------------
 
 variable "operator_ip" {


### PR DESCRIPTION
## Summary
- **Bug (prod):** since the Heroku → Azure cutover, every email send has 500'd with `OSError: [Errno 99] Cannot assign requested address` from Django's SMTP backend. Heroku's Mailgun addon supplied the SMTP config implicitly, so the migration never set `DJANGO_EMAIL_*` on Azure and `settings.py` fell back to `localhost:25`. Surfaced 2026-07-08 when inviting a survey collaborator.
- **Fix:** add the email settings to Terraform's `app_settings` (it owns the whole map, so `az webapp config appsettings set` would be wiped on the next `tofu apply`): `DJANGO_EMAIL_HOST/PORT/USE_TLS` fixed to Mailgun SMTP, plus new `mailgun_smtp_user` / `mailgun_smtp_password` (sensitive) / `default_from_email` variables, documented in `terraform.tfvars.example`.
- **Docs:** `docs/deployment/migration.md` gains a danger admonition in the cutover step: symptom, why it appears weeks late, the Terraform-first fix, where the real SMTP credentials live (not the API key), and how to pull the traceback from the `containerStream` container logs.

## Test plan
- `tofu validate` passes.
- Config-only + docs; no app code. After merge: set `mailgun_smtp_user` in local tfvars, `export TF_VAR_mailgun_smtp_password`, `tofu apply`, send a survey invite, confirm the email arrives and the log stream shows no traceback.