### PR TITLE
Content planner: one-click and bulk "mark done" for posts

### DIFF
--- a/content_planner/templates/content_planner/_post_row.html
+++ b/content_planner/templates/content_planner/_post_row.html
@@ -34,6 +34,17 @@ bulk-select checkbox (associated with the campaign's #bulk-form).{% endcomment %
             </small>
         {% endif %}
         {% include "content_planner/_status_badge.html" with value=post.status label=post.get_status_display %}
+        {% if post.status != "published" %}
+            <form method="post"
+                  class="d-inline"
+                  action="{% url 'content_planner:post_mark_done' board.slug post.campaign.slug post.slug %}">
+                {% csrf_token %}
+                <input type="hidden" name="next" value="{{ request.get_full_path }}">
+                <button type="submit"
+                        class="btn btn-sm btn-outline-success"
+                        title="Mark done">{% icon "check" label="Mark done" %}</button>
+            </form>
+        {% endif %}
         <a class="btn btn-sm btn-outline-secondary"
            href="{% url 'content_planner:post_edit' board.slug post.campaign.slug post.slug %}"
            title="Edit">{% icon "pen-to-square" label="Edit" %}</a>

--- a/content_planner/templates/content_planner/_post_row.html
+++ b/content_planner/templates/content_planner/_post_row.html
@@ -42,7 +42,9 @@ bulk-select checkbox (associated with the campaign's #bulk-form).{% endcomment %
                 <input type="hidden" name="next" value="{{ request.get_full_path }}">
                 <button type="submit"
                         class="btn btn-sm btn-outline-success"
-                        title="Mark done">{% icon "check" label="Mark done" %}</button>
+                        title="Mark done">
+                    {% icon "check" label="Mark done" %}
+                </button>
             </form>
         {% endif %}
         <a class="btn btn-sm btn-outline-secondary"

--- a/content_planner/templates/content_planner/campaign_detail.html
+++ b/content_planner/templates/content_planner/campaign_detail.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load icons %}
 {% block head_title %}
     {{ campaign.name }} · {{ board.name }} · {{ block.super }}
 {% endblock head_title %}
@@ -122,6 +123,12 @@
                     Select all
                 </label>
             </div>
+            <button type="submit"
+                    name="quick_action"
+                    value="mark_done"
+                    class="btn btn-sm btn-success">
+                {% icon "check" %} Mark selected done
+            </button>
             <select name="action"
                     class="form-select form-select-sm w-auto"
                     aria-label="Bulk action">

--- a/content_planner/urls.py
+++ b/content_planner/urls.py
@@ -77,6 +77,11 @@ urlpatterns = [
         name="post_edit",
     ),
     path(
+        "<slug:board_slug>/c/<slug:slug>/p/<slug:post_slug>/mark-done/",
+        views.post_mark_done,
+        name="post_mark_done",
+    ),
+    path(
         "<slug:board_slug>/c/<slug:slug>/p/<slug:post_slug>/delete/",
         views.post_delete,
         name="post_delete",

--- a/content_planner/views.py
+++ b/content_planner/views.py
@@ -10,6 +10,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.template.defaultfilters import pluralize
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods, require_POST
 from django_ratelimit.decorators import ratelimit
@@ -305,9 +306,14 @@ def campaign_bulk_update(request, board, slug):
     campaign = get_object_or_404(Campaign, board=board, slug=slug)
     posts = campaign.posts.filter(pk__in=request.POST.getlist("posts"))
     count = posts.count()
-    action = request.POST.get("action")
+    # A one-click shortcut button ("Mark done") wins over the action dropdown,
+    # which is always submitted alongside it.
+    action = request.POST.get("quick_action") or request.POST.get("action")
     if not count:
         messages.info(request, "No posts selected.")
+    elif action == "mark_done":
+        posts.update(status=Post.Status.PUBLISHED, modified_date=timezone.now())
+        messages.success(request, f"Marked {count} post{pluralize(count)} done.")
     elif action == "set_status":
         status = request.POST.get("status")
         if status in Post.Status.values:
@@ -395,6 +401,32 @@ def post_delete(request, board, slug, post_slug):
     title = post.title
     post.delete()
     messages.success(request, f"Deleted post '{title}'.")
+    return redirect(
+        "content_planner:campaign_detail",
+        board_slug=board.slug,
+        slug=campaign.slug,
+    )
+
+
+@board_required
+@require_http_methods(["POST"])
+def post_mark_done(request, board, slug, post_slug):
+    """Mark a single post published — the one-click row shortcut.
+
+    Rows appear on several pages, so the caller passes ``next`` to come back
+    to where the button was clicked; anything off-site falls back to the
+    campaign.
+    """
+    campaign = get_object_or_404(Campaign, board=board, slug=slug)
+    post = get_object_or_404(Post, campaign=campaign, slug=post_slug)
+    post.status = Post.Status.PUBLISHED
+    post.save(update_fields=["status"])
+    messages.success(request, f"Marked '{post.title}' done.")
+    next_url = request.POST.get("next", "")
+    if next_url and url_has_allowed_host_and_scheme(
+        next_url, allowed_hosts={request.get_host()}, require_https=request.is_secure()
+    ):
+        return redirect(next_url)
     return redirect(
         "content_planner:campaign_detail",
         board_slug=board.slug,

--- a/tests/test_content_planner_views.py
+++ b/tests/test_content_planner_views.py
@@ -511,6 +511,74 @@ def test_bulk_unknown_action_rejected(auth_client, board, campaign):
     assert post.status == "drafting"
 
 
+def test_bulk_mark_done_wins_over_action_dropdown(auth_client, board, campaign):
+    p1 = Post.objects.create(campaign=campaign, title="A", channel="blog")
+    p2 = Post.objects.create(campaign=campaign, title="B", channel="blog")
+    resp = auth_client.post(
+        _bulk_url(board, campaign),
+        {
+            "posts": [p1.pk, p2.pk],
+            "quick_action": "mark_done",
+            "action": "set_status",
+            "status": "drafting",
+        },
+    )
+    assert resp.status_code == 302
+    p1.refresh_from_db()
+    p2.refresh_from_db()
+    assert p1.status == "published"
+    assert p2.status == "published"
+
+
+def _mark_done_url(board, campaign, post):
+    return reverse(
+        "content_planner:post_mark_done",
+        kwargs={
+            "board_slug": board.slug,
+            "slug": campaign.slug,
+            "post_slug": post.slug,
+        },
+    )
+
+
+def test_post_mark_done(auth_client, board, campaign):
+    post = Post.objects.create(
+        campaign=campaign, title="A", channel="blog", status="drafting"
+    )
+    resp = auth_client.post(_mark_done_url(board, campaign, post))
+    assert resp.status_code == 302
+    assert resp["Location"] == reverse(
+        "content_planner:campaign_detail",
+        kwargs={"board_slug": board.slug, "slug": campaign.slug},
+    )
+    post.refresh_from_db()
+    assert post.status == "published"
+
+
+def test_post_mark_done_returns_to_next(auth_client, board, campaign):
+    post = Post.objects.create(campaign=campaign, title="A", channel="blog")
+    board_home = reverse(
+        "content_planner:board_home", kwargs={"board_slug": board.slug}
+    )
+    resp = auth_client.post(
+        _mark_done_url(board, campaign, post), {"next": board_home}
+    )
+    assert resp.status_code == 302
+    assert resp["Location"] == board_home
+
+
+def test_post_mark_done_rejects_offsite_next(auth_client, board, campaign):
+    post = Post.objects.create(campaign=campaign, title="A", channel="blog")
+    resp = auth_client.post(
+        _mark_done_url(board, campaign, post), {"next": "https://evil.example/"}
+    )
+    assert resp.status_code == 302
+    assert resp["Location"] == reverse(
+        "content_planner:campaign_detail",
+        kwargs={"board_slug": board.slug, "slug": campaign.slug},
+    )
+
+
 def test_post_delete(auth_client, board, campaign):
     post = Post.objects.create(campaign=campaign, title="Doomed", channel="blog")
     resp = auth_client.post(

--- a/tests/test_content_planner_views.py
+++ b/tests/test_content_planner_views.py
@@ -560,9 +560,7 @@ def test_post_mark_done_returns_to_next(auth_client, board, campaign):
     board_home = reverse(
         "content_planner:board_home", kwargs={"board_slug": board.slug}
     )
-    resp = auth_client.post(
-        _mark_done_url(board, campaign, post), {"next": board_home}
-    )
+    resp = auth_client.post(_mark_done_url(board, campaign, post), {"next": board_home})
     assert resp.status_code == 302
     assert resp["Location"] == board_home
 


### PR DESCRIPTION
Marking a post finished took an edit-form round trip, or picking "published" out of the bulk status dropdown. Both are more clicks than the common case deserves.

### What's new

- **Per-row check button** next to Edit/Delete in `_post_row.html`, hidden once a post is published. It posts a `next` so you land back where you clicked: the row renders on both campaign detail and the board home.
- **"Mark selected done"** button in the campaign bulk toolbar. Submitted as `quick_action`, which wins over the `action` dropdown that the form always submits alongside it.
- New `post_mark_done` view + route; `campaign_bulk_update` gained a `mark_done` branch.

"Done" means `Status.PUBLISHED`, matching the "done / still planned" stat tile and the overdue rule.

### Notes

- The row button is one-way by design: no undo beyond editing the post.
- `next` is validated with `url_has_allowed_host_and_scheme`; off-site values fall back to the campaign page.

### Tests

4 new view tests (bulk shortcut precedence, single mark-done, `next` redirect, off-site `next` rejection). Full suite: 980 passed.