### PR TITLE
Social publishing M2: Mastodon connector and connect flow

### DIFF
--- a/content_planner/connectors/base.py
+++ b/content_planner/connectors/base.py
@@ -50,7 +50,16 @@ class PlatformLimits(NamedTuple):
 
 
 class PublishError(Exception):
-    """Base for delivery failures."""
+    """Base for delivery failures.
+
+    ``status_code`` is carried so callers can react to specific rejections
+    (a 401 means the account needs reconnecting, not that the post is bad)
+    without re-parsing the message.
+    """
+
+    def __init__(self, message, status_code=None):
+        super().__init__(message)
+        self.status_code = status_code
 
 
 class TransientPublishError(PublishError):

--- a/content_planner/connectors/mastodon.py
+++ b/content_planner/connectors/mastodon.py
@@ -1,0 +1,223 @@
+"""Mastodon connector.
+
+The simplest real platform, and the only one of the three with server-side
+idempotency: ``Idempotency-Key`` means a retry after a timeout that actually
+succeeded returns the original status instead of posting twice.
+
+Everything here is per-instance. Character limits, accepted MIME types, and
+the client registration itself all differ between servers, so they are read
+from the instance and cached on the account rather than hard-coded.
+"""
+
+import time
+
+from django.conf import settings
+from django.utils import timezone
+
+from ..models import MastodonApp, Platform, PublishingAccount
+from .base import PermanentPublishError, PlatformLimits, PublishResult
+from .transport import fetch_bytes, request
+
+CLIENT_NAME = "Secret Codes content planner"
+SCOPES = "read:accounts write:statuses write:media"
+
+# Used until the instance tells us otherwise (Mastodon's own defaults).
+FALLBACK_MAX_CHARS = 500
+FALLBACK_MAX_ASSET_BYTES = 10 * 1024 * 1024
+FALLBACK_MIMES = frozenset(
+    {"image/jpeg", "image/png", "image/gif", "image/webp", "image/avif"}
+)
+MAX_ASSETS = 4
+
+# Media is processed asynchronously; a status must not reference an
+# attachment that is still converting.
+MEDIA_POLL_INTERVAL = 1
+MEDIA_POLL_ATTEMPTS = 30
+
+
+def _api(host, path):
+    return f"https://{host}{path}"
+
+
+def _auth(account):
+    return {"Authorization": f"Bearer {account.access_token}"}
+
+
+def register_app(host):
+    """Register this app with one instance, or reuse the stored registration."""
+    existing = MastodonApp.objects.filter(instance_host=host).first()
+    if existing:
+        return existing
+    response = request(
+        "POST",
+        _api(host, "/api/v1/apps"),
+        data={
+            "client_name": CLIENT_NAME,
+            "redirect_uris": settings.MASTODON_REDIRECT_URI,
+            "scopes": SCOPES,
+            "website": settings.DOMAIN_NAME,
+        },
+    )
+    payload = response.json()
+    return MastodonApp.objects.create(
+        instance_host=host,
+        client_id=payload["client_id"],
+        client_secret=payload["client_secret"],
+    )
+
+
+class MastodonConnector:
+    platform = Platform.MASTODON
+
+    def limits(self, account):
+        """Instance limits, read at connect time and cached on the account."""
+        metadata = account.metadata or {}
+        mimes = metadata.get("supported_mimes")
+        return PlatformLimits(
+            max_chars=metadata.get("max_chars", FALLBACK_MAX_CHARS),
+            max_hashtags=None,
+            max_assets=MAX_ASSETS,
+            requires_asset=False,
+            allowed_mimes=frozenset(mimes) if mimes else FALLBACK_MIMES,
+            max_asset_bytes=metadata.get("max_asset_bytes", FALLBACK_MAX_ASSET_BYTES),
+        )
+
+    def authorize_url(self, state, *, host):
+        app = register_app(host)
+        query = "&".join(
+            [
+                f"client_id={app.client_id}",
+                f"redirect_uri={settings.MASTODON_REDIRECT_URI}",
+                "response_type=code",
+                f"scope={SCOPES.replace(' ', '+')}",
+                f"state={state}",
+            ]
+        )
+        return _api(host, f"/oauth/authorize?{query}")
+
+    def exchange(self, code, state, *, host, owner):
+        """Trade the callback code for a token and store the account."""
+        app = register_app(host)
+        token = request(
+            "POST",
+            _api(host, "/oauth/token"),
+            data={
+                "grant_type": "authorization_code",
+                "client_id": app.client_id,
+                "client_secret": app.client_secret,
+                "redirect_uri": settings.MASTODON_REDIRECT_URI,
+                "code": code,
+                "scope": SCOPES,
+            },
+        ).json()
+        access_token = token["access_token"]
+
+        who = request(
+            "GET",
+            _api(host, "/api/v1/accounts/verify_credentials"),
+            headers={"Authorization": f"Bearer {access_token}"},
+        ).json()
+
+        account, _ = PublishingAccount.objects.update_or_create(
+            owner=owner,
+            platform=Platform.MASTODON,
+            remote_id=str(who["id"]),
+            defaults={
+                "handle": who["acct"],
+                "instance_url": f"https://{host}",
+                "access_token": access_token,
+                # Mastodon tokens do not expire; they are revoked instead.
+                "expires_at": None,
+                "scopes": SCOPES.split(),
+                "status": PublishingAccount.Status.ACTIVE,
+                "last_verified_at": timezone.now(),
+                "metadata": read_instance_limits(host),
+            },
+        )
+        return account
+
+    def refresh(self, account):
+        """No refresh flow: Mastodon tokens live until revoked.
+
+        Re-verifying is how a revoked token surfaces, so that is what this
+        does; a 401 raises and the caller flags the account.
+        """
+        request(
+            "GET",
+            _api(self._host(account), "/api/v1/accounts/verify_credentials"),
+            headers=_auth(account),
+        )
+        account.last_verified_at = timezone.now()
+        account.save(update_fields=["last_verified_at"])
+
+    def publish(self, account, payload, idempotency_key):
+        host = self._host(account)
+        media_ids = [self._upload(host, account, a) for a in payload.assets]
+        data = [("status", payload.text), ("visibility", "public"), ("language", "en")]
+        data += [("media_ids[]", media_id) for media_id in media_ids]
+        status = request(
+            "POST",
+            _api(host, "/api/v1/statuses"),
+            headers={**_auth(account), "Idempotency-Key": idempotency_key},
+            data=data,
+        ).json()
+        return PublishResult(
+            remote_id=str(status["id"]),
+            remote_url=status.get("url", ""),
+            raw=status,
+        )
+
+    def _upload(self, host, account, asset):
+        """Upload one attachment and wait for the instance to finish with it."""
+        response = request(
+            "POST",
+            _api(host, "/api/v2/media"),
+            headers=_auth(account),
+            files={"file": (asset.url.rsplit("/", 1)[-1], fetch_bytes(asset.url))},
+            data={"description": asset.alt},
+        )
+        media = response.json()
+        if response.status_code == 202:
+            self._await_processing(host, account, media["id"])
+        return media["id"]
+
+    def _await_processing(self, host, account, media_id):
+        """202 means "still converting" — poll until the URL exists."""
+        for _ in range(MEDIA_POLL_ATTEMPTS):
+            response = request(
+                "GET",
+                _api(host, f"/api/v1/media/{media_id}"),
+                headers=_auth(account),
+            )
+            if response.status_code == 200 and response.json().get("url"):
+                return
+            time.sleep(MEDIA_POLL_INTERVAL)
+        raise PermanentPublishError(
+            f"Attachment {media_id} was still processing after "
+            f"{MEDIA_POLL_ATTEMPTS * MEDIA_POLL_INTERVAL}s."
+        )
+
+    def _host(self, account):
+        host = (account.instance_url or "").removeprefix("https://").strip("/")
+        if not host:
+            raise PermanentPublishError(
+                f"{account.handle} has no instance URL to publish to."
+            )
+        return host
+
+
+def read_instance_limits(host):
+    """Cacheable facts about one instance, for `limits()` and preflight."""
+    configuration = (
+        request("GET", _api(host, "/api/v1/instance")).json().get("configuration", {})
+    )
+    statuses = configuration.get("statuses", {})
+    media = configuration.get("media_attachments", {})
+    limits = {
+        "max_chars": statuses.get("max_characters", FALLBACK_MAX_CHARS),
+        "max_asset_bytes": media.get("image_size_limit", FALLBACK_MAX_ASSET_BYTES),
+    }
+    supported = media.get("supported_mime_types")
+    if supported:
+        limits["supported_mimes"] = supported
+    return limits

--- a/content_planner/connectors/transport.py
+++ b/content_planner/connectors/transport.py
@@ -1,0 +1,54 @@
+"""HTTP for connectors: one place that decides what is retryable.
+
+Every platform call goes through :func:`request`, so the transient/permanent
+split is made once, from the status code, rather than in each connector.
+"""
+
+import requests
+
+from .base import PermanentPublishError, TransientPublishError
+
+# Platform calls are made inside a worker holding a claimed row: a hung
+# connection would stall the whole tick, so nothing waits forever.
+DEFAULT_TIMEOUT = 30
+TRANSIENT_STATUSES = frozenset({408, 409, 425, 429, 500, 502, 503, 504})
+
+
+def request(method, url, *, timeout=DEFAULT_TIMEOUT, **kwargs):
+    """Make a call and normalise its failure into the two connector errors.
+
+    A network error is transient by definition: we cannot know whether the
+    request landed, so the caller retries and relies on the idempotency key.
+    """
+    try:
+        response = requests.request(method, url, timeout=timeout, **kwargs)
+    except requests.RequestException as exc:
+        raise TransientPublishError(f"{method} {url} failed: {exc}") from exc
+
+    if response.status_code in TRANSIENT_STATUSES:
+        raise TransientPublishError(
+            f"{method} {url} returned {response.status_code}: {_detail(response)}",
+            status_code=response.status_code,
+        )
+    if response.status_code >= 400:
+        raise PermanentPublishError(
+            f"{method} {url} returned {response.status_code}: {_detail(response)}",
+            status_code=response.status_code,
+        )
+    return response
+
+
+def _detail(response):
+    """The platform's own error message, when it sends one."""
+    try:
+        payload = response.json()
+    except ValueError:
+        return response.text[:200]
+    if isinstance(payload, dict):
+        return str(payload.get("error") or payload.get("message") or payload)[:200]
+    return str(payload)[:200]
+
+
+def fetch_bytes(url):
+    """Download an asset so it can be uploaded to a platform."""
+    return request("GET", url).content

--- a/content_planner/models.py
+++ b/content_planner/models.py
@@ -24,6 +24,7 @@ RESERVED_BOARD_SLUGS = frozenset(
         "schedule",
         "assets",
         "campaigns",
+        "publishing",
         "c",
         "mcp",
         "admin",

--- a/content_planner/payloads.py
+++ b/content_planner/payloads.py
@@ -6,6 +6,8 @@ without any platform, and identical to what preflight measured.
 
 import mimetypes
 
+from django.conf import settings
+
 from .connectors import AssetRef, PublishPayload
 
 # The asset extensions the planner knows about, mapped for platforms that care.
@@ -23,10 +25,20 @@ def mime_for(asset):
     return mimetypes.types_map.get(extension, "")
 
 
+def absolute_url(url):
+    """Connectors fetch assets over HTTP, so a MEDIA_URL path is not enough.
+
+    Local storage yields "/media/…"; Spaces already yields an absolute URL.
+    """
+    if url.startswith("/"):
+        return f"{settings.DOMAIN_NAME.rstrip('/')}{url}"
+    return url
+
+
 def asset_ref(asset):
     """The connector-facing view of one asset. ``caption`` is the alt text."""
     return AssetRef(
-        url=asset.media_url,
+        url=absolute_url(asset.media_url),
         mime=mime_for(asset),
         alt=asset.caption,
         byte_size=asset.file.size if asset.file else 0,

--- a/content_planner/tasks.py
+++ b/content_planner/tasks.py
@@ -16,7 +16,7 @@ from django.db.models import Q
 from django.utils import timezone
 
 from .connectors import PermanentPublishError, TransientPublishError, connector_for
-from .models import Publication
+from .models import Publication, PublishingAccount
 from .payloads import build_payload
 from .preflight import preflight
 
@@ -30,6 +30,8 @@ RETRY_BACKOFF = [
     timedelta(hours=4),
 ]
 CLAIM_BATCH_SIZE = 50
+# Platform responses that mean "this credential is done", not "this post is bad".
+REAUTH_STATUSES = frozenset({401, 403})
 
 
 @shared_task(name="content_planner.dispatch_due_publications")
@@ -152,7 +154,20 @@ def _fail(publication, exc):
     publication.last_error = str(exc)
     publication.save(update_fields=["state", "attempts", "last_error"])
     logger.warning("publication %s failed: %s", publication.pk, exc)
+    if getattr(exc, "status_code", None) in REAUTH_STATUSES:
+        _flag_for_reauth(publication.account)
     return publication.state
+
+
+def _flag_for_reauth(account):
+    """The token was rejected: stop trying and ask for a reconnect.
+
+    Every other publication for this account preflights as blocked from here
+    on, which is the visible-failure half of "nothing is skipped silently".
+    """
+    account.status = PublishingAccount.Status.NEEDS_REAUTH
+    account.save(update_fields=["status"])
+    logger.warning("account %s needs reconnecting", account.pk)
 
 
 def _retry_later(publication, exc):

--- a/content_planner/templates/content_planner/index.html
+++ b/content_planner/templates/content_planner/index.html
@@ -7,8 +7,12 @@
         <h1 class="h3 mb-0">
             Your <em class="sc-italic">boards</em>
         </h1>
-        <a class="btn btn-primary"
-           href="{% url 'content_planner:board_create' %}">+ New board</a>
+        <div class="d-flex gap-2">
+            <a class="btn btn-outline-secondary"
+               href="{% url 'content_planner:publishing_accounts' %}">Publishing accounts</a>
+            <a class="btn btn-primary"
+               href="{% url 'content_planner:board_create' %}">+ New board</a>
+        </div>
     </div>
     {% if rows %}
         <div class="list-group">

--- a/content_planner/templates/content_planner/publishing_accounts.html
+++ b/content_planner/templates/content_planner/publishing_accounts.html
@@ -1,0 +1,75 @@
+{% extends "base.html" %}
+{% block head_title %}
+    Your publishing accounts · Content · {{ block.super }}
+{% endblock head_title %}
+{% block content %}
+    <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+            <li class="breadcrumb-item">
+                <a href="{% url 'content_planner:index' %}">All boards</a>
+            </li>
+            <li class="breadcrumb-item active" aria-current="page">
+                Publishing accounts
+            </li>
+        </ol>
+    </nav>
+    <div class="d-flex justify-content-between align-items-center mb-4">
+        <h1 class="h3 mb-0">
+            Your <em class="sc-italic">publishing accounts</em>
+        </h1>
+    </div>
+    {% if accounts %}
+        <div class="list-group mb-4">
+            {% for account in accounts %}
+                <div class="list-group-item d-flex justify-content-between align-items-start gap-2">
+                    <span>
+                        <span class="fw-semibold">{{ account.handle }}</span>
+                        <br>
+                        <small class="text-muted">
+                            {{ account.get_platform_display }}
+                            {% if account.instance_url %}· {{ account.instance_url }}{% endif %}
+                        </small>
+                    </span>
+                    <span class="text-end d-flex align-items-center gap-2">
+                        {% if account.status == needs_reauth %}
+                            <span class="badge bg-warning text-dark">Needs reconnecting</span>
+                        {% elif account.status == "revoked" %}
+                            <span class="badge bg-secondary">Disconnected</span>
+                        {% else %}
+                            <span class="badge bg-success">Active</span>
+                        {% endif %}
+                        <form method="post"
+                              action="{% url 'content_planner:publishing_account_disconnect' account.pk %}"
+                              onsubmit="return confirm('Disconnect this account? Scheduled posts to it will stop.');">
+                            {% csrf_token %}
+                            <button type="submit" class="btn btn-sm btn-outline-danger">Disconnect</button>
+                        </form>
+                    </span>
+                </div>
+            {% endfor %}
+        </div>
+    {% else %}
+        <p class="text-muted">
+            No accounts connected yet. Connect one to schedule posts to it.
+        </p>
+    {% endif %}
+    <h2 class="h5">
+        Connect Mastodon
+    </h2>
+    <p class="text-muted small">
+        Enter your instance, for example <code>fosstodon.org</code>. You will be
+        sent there to authorise, and sent back here afterwards.
+    </p>
+    <form method="post"
+          action="{% url 'content_planner:mastodon_connect' %}"
+          class="d-flex flex-wrap gap-2 align-items-center">
+        {% csrf_token %}
+        <input type="text"
+               name="instance"
+               class="form-control w-auto"
+               placeholder="fosstodon.org"
+               aria-label="Mastodon instance"
+               required>
+        <button type="submit" class="btn btn-primary">Connect</button>
+    </form>
+{% endblock content %}

--- a/content_planner/urls.py
+++ b/content_planner/urls.py
@@ -7,6 +7,28 @@ app_name = "content_planner"
 urlpatterns = [
     path("", views.index, name="index"),
     path("new/", views.board_create, name="board_create"),
+    # Publishing accounts are per-user, not per-board, so these sit above the
+    # <board_slug> patterns — otherwise "publishing" reads as a board slug.
+    path(
+        "publishing/accounts/",
+        views.publishing_accounts,
+        name="publishing_accounts",
+    ),
+    path(
+        "publishing/connect/mastodon/",
+        views.mastodon_connect,
+        name="mastodon_connect",
+    ),
+    path(
+        "publishing/connect/mastodon/callback/",
+        views.mastodon_callback,
+        name="mastodon_callback",
+    ),
+    path(
+        "publishing/accounts/<int:pk>/disconnect/",
+        views.publishing_account_disconnect,
+        name="publishing_account_disconnect",
+    ),
     path("<slug:board_slug>/", views.board_home, name="board_home"),
     path("<slug:board_slug>/schedule/", views.schedule, name="schedule"),
     path("<slug:board_slug>/assets/", views.asset_list, name="asset_list"),

--- a/content_planner/views.py
+++ b/content_planner/views.py
@@ -5,14 +5,24 @@ import markdown
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import user_passes_test
-from django.http import Http404, HttpResponse, JsonResponse
+from django.http import (
+    Http404,
+    HttpResponse,
+    HttpResponseBadRequest,
+    JsonResponse,
+)
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template.defaultfilters import pluralize
 from django.urls import reverse
 from django.utils import timezone
+from django.utils.crypto import get_random_string
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.views.decorators.csrf import csrf_exempt
-from django.views.decorators.http import require_http_methods, require_POST
+from django.views.decorators.http import (
+    require_GET,
+    require_http_methods,
+    require_POST,
+)
 from django_ratelimit.decorators import ratelimit
 
 from .billing import check_quota
@@ -21,9 +31,11 @@ from .chat_import import (
     create_campaign_from_payload,
     parse_chat_payload,
 )
+from .connectors import PublishError
+from .connectors.mastodon import MastodonConnector
 from .forms import AssetForm, BoardForm, CampaignForm, PostCreateForm, PostForm
 from .mcp import dispatch as mcp_dispatch
-from .models import Asset, Campaign, ContentBoard, Post
+from .models import Asset, Campaign, ContentBoard, Post, PublishingAccount
 from .permissions import can_access_board, is_content_user
 from .schemas import SCHEMA_DIR
 from .selectors import (
@@ -578,3 +590,93 @@ def content_mcp_endpoint(request):
     if response_payload is None:
         return HttpResponse(status=202)
     return JsonResponse(response_payload)
+
+
+# ------------------------------------------------------- publishing accounts
+
+
+@user_passes_test(is_content_user)
+@require_GET
+def publishing_accounts(request):
+    """The accounts this user can publish to, and their health."""
+    accounts = PublishingAccount.objects.filter(owner=request.user)
+    return render(
+        request,
+        "content_planner/publishing_accounts.html",
+        {"accounts": accounts, "needs_reauth": PublishingAccount.Status.NEEDS_REAUTH},
+    )
+
+
+@user_passes_test(is_content_user)
+@require_POST
+def mastodon_connect(request):
+    """Register with the given instance and send the user off to authorise."""
+    host = _mastodon_host(request.POST.get("instance", ""))
+    if not host:
+        messages.error(request, "Enter a Mastodon instance, e.g. fosstodon.org.")
+        return redirect("content_planner:publishing_accounts")
+    state = get_random_string(32)
+    request.session["mastodon_oauth_state"] = state
+    request.session["mastodon_oauth_host"] = host
+    try:
+        url = MastodonConnector().authorize_url(state, host=host)
+    except PublishError as exc:
+        messages.error(request, f"Could not reach {host}: {exc}")
+        return redirect("content_planner:publishing_accounts")
+    return redirect(url)
+
+
+@user_passes_test(is_content_user)
+@require_GET
+def mastodon_callback(request):
+    """Exchange the authorisation code and store the account."""
+    expected_state = request.session.pop("mastodon_oauth_state", None)
+    host = request.session.pop("mastodon_oauth_host", None)
+    if not expected_state or request.GET.get("state") != expected_state:
+        return HttpResponseBadRequest("Invalid OAuth state")
+    code = request.GET.get("code")
+    if not code:
+        return HttpResponseBadRequest("Missing authorization code")
+    try:
+        account = MastodonConnector().exchange(
+            code, expected_state, host=host, owner=request.user
+        )
+    except PublishError as exc:
+        messages.error(request, f"Could not connect to {host}: {exc}")
+    else:
+        messages.success(request, f"Connected {account.handle}.")
+    return redirect("content_planner:publishing_accounts")
+
+
+@user_passes_test(is_content_user)
+@require_POST
+def publishing_account_disconnect(request, pk):
+    """Forget an account.
+
+    PROTECT on Publication.account means an account with delivery history
+    cannot be deleted; it is marked revoked instead, so the history that
+    references it survives.
+    """
+    account = get_object_or_404(PublishingAccount, pk=pk, owner=request.user)
+    handle = account.handle
+    if account.publication_set.exists():
+        account.status = PublishingAccount.Status.REVOKED
+        account.access_token = ""
+        account.refresh_token = ""
+        account.save(update_fields=["status", "access_token", "refresh_token"])
+        messages.success(
+            request, f"Disconnected {handle}. Its delivery history is kept."
+        )
+    else:
+        account.delete()
+        messages.success(request, f"Disconnected {handle}.")
+    return redirect("content_planner:publishing_accounts")
+
+
+def _mastodon_host(raw):
+    """Accept "fosstodon.org", "@me@fosstodon.org", or a pasted URL."""
+    host = raw.strip().rstrip("/")
+    if "@" in host:
+        host = host.rsplit("@", 1)[-1]
+    host = host.removeprefix("https://").removeprefix("http://")
+    return host.split("/")[0]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,3 +9,4 @@ pip-audit==2.10.1
 pytest-django==4.12.0
 pytest==9.1.1
 pytest-cov==7.1.0
+responses==0.26.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,4 +29,5 @@ pillow==12.3.0
 qrcode==8.2
 qrcode[pil]
 redis==8.0.1
+requests==2.34.2
 regex==2026.6.28

--- a/secretcodes/settings.py
+++ b/secretcodes/settings.py
@@ -384,9 +384,19 @@ CELERY_BEAT_SCHEDULE = {
 PUBLICATION_CLAIM_TIMEOUT_MINUTES = int(
     os.environ.get("PUBLICATION_CLAIM_TIMEOUT_MINUTES", "15")
 )
-# Platform -> Connector dotted path. Empty until a real connector lands (M2+);
-# a publication for an unmapped platform fails loudly rather than silently.
-CONTENT_PLANNER_CONNECTORS = {}
+# Platform -> Connector dotted path. A publication for an unmapped platform
+# fails loudly rather than silently; platforms land one milestone at a time.
+CONTENT_PLANNER_CONNECTORS = {
+    "mastodon": "content_planner.connectors.mastodon.MastodonConnector",
+}
+
+# Where Mastodon sends the user back after they authorise. Must match exactly
+# what was registered with each instance (it is part of the app registration),
+# so changing it means re-registering: delete the MastodonApp rows.
+MASTODON_REDIRECT_URI = os.environ.get(
+    "MASTODON_REDIRECT_URI",
+    f"{DOMAIN_NAME.rstrip('/')}/content/publishing/connect/mastodon/callback/",
+)
 
 # Public API rate limits. Override via env var for testing or tuning.
 MCP_RATE_LIMIT = os.environ.get("MCP_RATE_LIMIT", "60/m")

--- a/tests/test_content_planner_mastodon.py
+++ b/tests/test_content_planner_mastodon.py
@@ -1,0 +1,490 @@
+"""Mastodon connector: registration, OAuth, media processing, publishing.
+
+Every HTTP call is mocked with `responses`. The point of these tests is the
+sequencing Mastodon requires — register once per instance, wait for media to
+finish converting, send the idempotency key — not that `requests` works.
+"""
+
+import pytest
+import requests
+import responses
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Permission
+from django.urls import reverse
+
+from content_planner.connectors import (
+    AssetRef,
+    PermanentPublishError,
+    PublishPayload,
+    TransientPublishError,
+    transport,
+)
+from content_planner.connectors.mastodon import (
+    FALLBACK_MAX_CHARS,
+    MEDIA_POLL_ATTEMPTS,
+    MastodonConnector,
+    read_instance_limits,
+    register_app,
+)
+from content_planner.models import MastodonApp, Platform, PublishingAccount
+
+User = get_user_model()
+
+HOST = "fosstodon.org"
+API = f"https://{HOST}"
+
+
+@pytest.fixture
+def user(db):
+    person = User.objects.create_user(username="owner", password="pw")
+    person.user_permissions.add(
+        Permission.objects.get(
+            codename="access_content_planner",
+            content_type__app_label="content_planner",
+        )
+    )
+    return person
+
+
+@pytest.fixture
+def auth_client(client, user):
+    client.force_login(user)
+    return client
+
+
+@pytest.fixture
+def account(user):
+    return PublishingAccount.objects.create(
+        owner=user,
+        platform=Platform.MASTODON,
+        remote_id="12345",
+        handle="mariatta@fosstodon.org",
+        instance_url=API,
+        access_token="token-abc",
+        metadata={"max_chars": 500, "max_asset_bytes": 2_000_000},
+    )
+
+
+@pytest.fixture
+def no_sleep(monkeypatch):
+    """Media polling sleeps between attempts; tests should not."""
+    monkeypatch.setattr(
+        "content_planner.connectors.mastodon.time.sleep", lambda s: None
+    )
+
+
+def mock_registration():
+    responses.post(
+        f"{API}/api/v1/apps",
+        json={"client_id": "cid", "client_secret": "csecret"},
+    )
+
+
+# ------------------------------------------------------------- app registry
+
+
+@responses.activate
+def test_register_app_stores_the_registration(db):
+    mock_registration()
+    app = register_app(HOST)
+    assert app.client_id == "cid"
+    assert MastodonApp.objects.count() == 1
+
+
+@responses.activate
+def test_register_app_reuses_an_existing_registration(db):
+    mock_registration()
+    first = register_app(HOST)
+    second = register_app(HOST)
+    assert first.pk == second.pk
+    assert len(responses.calls) == 1  # no second round trip
+
+
+@responses.activate
+def test_client_secret_is_encrypted_at_rest(db):
+    mock_registration()
+    register_app(HOST)
+    from django.db import connection
+
+    with connection.cursor() as cursor:
+        cursor.execute("SELECT client_secret FROM content_planner_mastodonapp")
+        assert cursor.fetchone()[0] != "csecret"
+
+
+# ---------------------------------------------------------------- instance
+
+
+@responses.activate
+def test_read_instance_limits_prefers_what_the_instance_reports(db):
+    responses.get(
+        f"{API}/api/v1/instance",
+        json={
+            "configuration": {
+                "statuses": {"max_characters": 11000},
+                "media_attachments": {
+                    "image_size_limit": 16_777_216,
+                    "supported_mime_types": ["image/jpeg"],
+                },
+            }
+        },
+    )
+    assert read_instance_limits(HOST) == {
+        "max_chars": 11000,
+        "max_asset_bytes": 16_777_216,
+        "supported_mimes": ["image/jpeg"],
+    }
+
+
+@responses.activate
+def test_read_instance_limits_falls_back_when_absent(db):
+    responses.get(f"{API}/api/v1/instance", json={})
+    limits = read_instance_limits(HOST)
+    assert limits["max_chars"] == FALLBACK_MAX_CHARS
+    assert "supported_mimes" not in limits
+
+
+def test_limits_use_cached_instance_facts(account):
+    limits = MastodonConnector().limits(account)
+    assert limits.max_chars == 500
+    assert limits.max_asset_bytes == 2_000_000
+    assert limits.requires_asset is False
+    assert "image/jpeg" in limits.allowed_mimes
+
+
+def test_limits_fall_back_without_metadata(account):
+    account.metadata = {}
+    limits = MastodonConnector().limits(account)
+    assert limits.max_chars == FALLBACK_MAX_CHARS
+
+
+# -------------------------------------------------------------------- auth
+
+
+@responses.activate
+def test_authorize_url_includes_state_and_scopes(db):
+    mock_registration()
+    url = MastodonConnector().authorize_url("st4te", host=HOST)
+    assert url.startswith(f"{API}/oauth/authorize?")
+    assert "client_id=cid" in url
+    assert "state=st4te" in url
+    assert "write%3Astatuses" in url or "write:statuses" in url
+
+
+@responses.activate
+def test_exchange_stores_the_account_and_instance_limits(user):
+    mock_registration()
+    responses.post(f"{API}/oauth/token", json={"access_token": "tok-1"})
+    responses.get(
+        f"{API}/api/v1/accounts/verify_credentials",
+        json={"id": 999, "acct": "mariatta"},
+    )
+    responses.get(
+        f"{API}/api/v1/instance",
+        json={"configuration": {"statuses": {"max_characters": 500}}},
+    )
+    account = MastodonConnector().exchange("code", "state", host=HOST, owner=user)
+    assert account.remote_id == "999"
+    assert account.handle == "mariatta"
+    assert account.access_token == "tok-1"
+    assert account.expires_at is None  # Mastodon tokens do not expire
+    assert account.status == PublishingAccount.Status.ACTIVE
+    assert account.metadata["max_chars"] == 500
+    assert account.last_verified_at is not None
+
+
+@responses.activate
+def test_exchange_is_idempotent_for_the_same_remote_account(user):
+    mock_registration()
+    responses.post(f"{API}/oauth/token", json={"access_token": "tok-2"})
+    responses.get(
+        f"{API}/api/v1/accounts/verify_credentials",
+        json={"id": 999, "acct": "mariatta"},
+    )
+    responses.get(f"{API}/api/v1/instance", json={})
+    connector = MastodonConnector()
+    connector.exchange("c", "s", host=HOST, owner=user)
+    connector.exchange("c", "s", host=HOST, owner=user)
+    assert PublishingAccount.objects.count() == 1
+
+
+@responses.activate
+def test_refresh_reverifies_and_stamps_the_account(account):
+    responses.get(f"{API}/api/v1/accounts/verify_credentials", json={"id": 1})
+    before = account.last_verified_at
+    MastodonConnector().refresh(account)
+    account.refresh_from_db()
+    assert account.last_verified_at != before
+
+
+@responses.activate
+def test_refresh_raises_when_the_token_was_revoked(account):
+    responses.get(
+        f"{API}/api/v1/accounts/verify_credentials",
+        json={"error": "The access token is invalid"},
+        status=401,
+    )
+    with pytest.raises(PermanentPublishError) as exc:
+        MastodonConnector().refresh(account)
+    assert exc.value.status_code == 401
+
+
+# ----------------------------------------------------------------- publish
+
+
+@responses.activate
+def test_publish_sends_the_idempotency_key(account):
+    responses.post(
+        f"{API}/api/v1/statuses",
+        json={"id": "110", "url": f"{API}/@mariatta/110"},
+    )
+    result = MastodonConnector().publish(
+        account, PublishPayload(text="Hello"), "key-123"
+    )
+    assert result.remote_id == "110"
+    assert result.remote_url == f"{API}/@mariatta/110"
+    assert responses.calls[0].request.headers["Idempotency-Key"] == "key-123"
+
+
+@responses.activate
+def test_publish_uploads_media_and_attaches_it(account, no_sleep):
+    responses.get("https://cdn.test/hero.jpg", body=b"jpegbytes")
+    responses.post(f"{API}/api/v2/media", json={"id": "m1", "url": "https://x/1"})
+    responses.post(f"{API}/api/v1/statuses", json={"id": "111", "url": "u"})
+    payload = PublishPayload(
+        text="With image",
+        assets=[
+            AssetRef(url="https://cdn.test/hero.jpg", mime="image/jpeg", alt="Alt")
+        ],
+    )
+    MastodonConnector().publish(account, payload, "key-1")
+    upload = responses.calls[1].request
+    assert b"Alt" in upload.body
+    assert b"media_ids%5B%5D=m1" in responses.calls[2].request.body.encode()
+
+
+@responses.activate
+def test_publish_waits_for_media_to_finish_processing(account, no_sleep):
+    """202 means still converting: attaching it now would post a broken status."""
+    responses.get("https://cdn.test/hero.jpg", body=b"jpegbytes")
+    responses.post(f"{API}/api/v2/media", json={"id": "m2", "url": None}, status=202)
+    responses.get(f"{API}/api/v1/media/m2", json={"id": "m2", "url": None})
+    responses.get(f"{API}/api/v1/media/m2", json={"id": "m2", "url": "https://x/2"})
+    responses.post(f"{API}/api/v1/statuses", json={"id": "112", "url": "u"})
+    payload = PublishPayload(
+        text="Slow media",
+        assets=[AssetRef(url="https://cdn.test/hero.jpg", mime="image/jpeg", alt="A")],
+    )
+    MastodonConnector().publish(account, payload, "key-2")
+    assert responses.calls[-1].request.url == f"{API}/api/v1/statuses"
+
+
+@responses.activate
+def test_publish_gives_up_on_media_stuck_processing(account, no_sleep):
+    responses.get("https://cdn.test/hero.jpg", body=b"jpegbytes")
+    responses.post(f"{API}/api/v2/media", json={"id": "m3", "url": None}, status=202)
+    for _ in range(MEDIA_POLL_ATTEMPTS):
+        responses.get(f"{API}/api/v1/media/m3", json={"id": "m3", "url": None})
+    payload = PublishPayload(
+        text="Stuck",
+        assets=[AssetRef(url="https://cdn.test/hero.jpg", mime="image/jpeg", alt="A")],
+    )
+    with pytest.raises(PermanentPublishError, match="still processing"):
+        MastodonConnector().publish(account, payload, "key-3")
+
+
+@responses.activate
+def test_publish_maps_rate_limiting_to_a_retry(account):
+    responses.post(f"{API}/api/v1/statuses", json={"error": "Slow down"}, status=429)
+    with pytest.raises(TransientPublishError) as exc:
+        MastodonConnector().publish(account, PublishPayload(text="x"), "k")
+    assert exc.value.status_code == 429
+
+
+@responses.activate
+def test_publish_maps_validation_failure_to_permanent(account):
+    responses.post(
+        f"{API}/api/v1/statuses", json={"error": "Text too long"}, status=422
+    )
+    with pytest.raises(PermanentPublishError, match="Text too long"):
+        MastodonConnector().publish(account, PublishPayload(text="x" * 9999), "k")
+
+
+def test_publish_without_an_instance_url_fails_clearly(account):
+    account.instance_url = ""
+    with pytest.raises(PermanentPublishError, match="no instance URL"):
+        MastodonConnector().publish(account, PublishPayload(text="x"), "k")
+
+
+# --------------------------------------------------------------- transport
+
+
+@responses.activate
+def test_transport_treats_network_errors_as_transient(db):
+    responses.get(
+        f"{API}/api/v1/instance", body=requests.exceptions.ConnectionError("boom")
+    )
+    with pytest.raises(TransientPublishError, match="failed"):
+        transport.request("GET", f"{API}/api/v1/instance")
+
+
+@responses.activate
+def test_transport_reports_non_json_errors(db):
+    responses.get(f"{API}/x", body="<html>gateway</html>", status=500)
+    with pytest.raises(TransientPublishError, match="gateway"):
+        transport.request("GET", f"{API}/x")
+
+
+@responses.activate
+def test_transport_reports_list_shaped_errors(db):
+    responses.get(f"{API}/x", json=["nope"], status=400)
+    with pytest.raises(PermanentPublishError, match="nope"):
+        transport.request("GET", f"{API}/x")
+
+
+@responses.activate
+def test_fetch_bytes_returns_content(db):
+    responses.get("https://cdn.test/a.jpg", body=b"abc")
+    assert transport.fetch_bytes("https://cdn.test/a.jpg") == b"abc"
+
+
+# ------------------------------------------------------------ connect flow
+
+
+def test_accounts_page_lists_accounts(auth_client, account):
+    response = auth_client.get(reverse("content_planner:publishing_accounts"))
+    assert response.status_code == 200
+    assert b"mariatta@fosstodon.org" in response.content
+    assert b"token-abc" not in response.content  # invariant: tokens never render
+
+
+def test_accounts_page_empty_state(auth_client):
+    response = auth_client.get(reverse("content_planner:publishing_accounts"))
+    assert b"No accounts connected yet" in response.content
+
+
+def test_accounts_page_requires_the_app_permission(client, db):
+    User.objects.create_user(username="plain", password="pw")
+    client.login(username="plain", password="pw")
+    response = client.get(reverse("content_planner:publishing_accounts"))
+    assert response.status_code == 302
+
+
+@responses.activate
+def test_connect_redirects_to_the_instance(auth_client):
+    mock_registration()
+    response = auth_client.post(
+        reverse("content_planner:mastodon_connect"), {"instance": "@me@fosstodon.org"}
+    )
+    assert response.status_code == 302
+    assert response["Location"].startswith(f"{API}/oauth/authorize")
+    assert auth_client.session["mastodon_oauth_host"] == HOST
+
+
+def test_connect_without_an_instance_says_so(auth_client):
+    response = auth_client.post(reverse("content_planner:mastodon_connect"), {})
+    assert response["Location"] == reverse("content_planner:publishing_accounts")
+
+
+@responses.activate
+def test_connect_surfaces_an_unreachable_instance(auth_client):
+    responses.post(f"{API}/api/v1/apps", json={"error": "nope"}, status=404)
+    response = auth_client.post(
+        reverse("content_planner:mastodon_connect"), {"instance": HOST}
+    )
+    assert response["Location"] == reverse("content_planner:publishing_accounts")
+    assert PublishingAccount.objects.count() == 0
+
+
+@responses.activate
+def test_callback_connects_the_account(auth_client, user):
+    mock_registration()
+    responses.post(f"{API}/oauth/token", json={"access_token": "tok"})
+    responses.get(
+        f"{API}/api/v1/accounts/verify_credentials", json={"id": 7, "acct": "m"}
+    )
+    responses.get(f"{API}/api/v1/instance", json={})
+    auth_client.post(reverse("content_planner:mastodon_connect"), {"instance": HOST})
+    state = auth_client.session["mastodon_oauth_state"]
+    response = auth_client.get(
+        reverse("content_planner:mastodon_callback"), {"code": "c", "state": state}
+    )
+    assert response["Location"] == reverse("content_planner:publishing_accounts")
+    assert PublishingAccount.objects.get(owner=user).handle == "m"
+
+
+def test_callback_rejects_a_mismatched_state(auth_client):
+    response = auth_client.get(
+        reverse("content_planner:mastodon_callback"), {"code": "c", "state": "wrong"}
+    )
+    assert response.status_code == 400
+
+
+@responses.activate
+def test_callback_requires_a_code(auth_client):
+    mock_registration()
+    auth_client.post(reverse("content_planner:mastodon_connect"), {"instance": HOST})
+    state = auth_client.session["mastodon_oauth_state"]
+    response = auth_client.get(
+        reverse("content_planner:mastodon_callback"), {"state": state}
+    )
+    assert response.status_code == 400
+
+
+@responses.activate
+def test_callback_surfaces_a_rejected_exchange(auth_client):
+    mock_registration()
+    responses.post(f"{API}/oauth/token", json={"error": "bad code"}, status=400)
+    auth_client.post(reverse("content_planner:mastodon_connect"), {"instance": HOST})
+    state = auth_client.session["mastodon_oauth_state"]
+    response = auth_client.get(
+        reverse("content_planner:mastodon_callback"), {"code": "c", "state": state}
+    )
+    assert response["Location"] == reverse("content_planner:publishing_accounts")
+    assert PublishingAccount.objects.count() == 0
+
+
+def test_disconnect_deletes_an_unused_account(auth_client, account):
+    response = auth_client.post(
+        reverse(
+            "content_planner:publishing_account_disconnect", kwargs={"pk": account.pk}
+        )
+    )
+    assert response.status_code == 302
+    assert PublishingAccount.objects.count() == 0
+
+
+def test_disconnect_keeps_an_account_with_history(auth_client, account, user):
+    """PROTECT means history wins: revoke rather than delete."""
+    from django.utils import timezone
+
+    from content_planner.models import Campaign, ContentBoard, Post, Publication
+
+    board = ContentBoard.objects.create(name="B", slug="b", owner=user)
+    campaign = Campaign.objects.create(board=board, name="C")
+    post = Post.objects.create(campaign=campaign, title="P", channel="mastodon")
+    Publication.objects.create(post=post, account=account, scheduled_for=timezone.now())
+    auth_client.post(
+        reverse(
+            "content_planner:publishing_account_disconnect", kwargs={"pk": account.pk}
+        )
+    )
+    account.refresh_from_db()
+    assert account.status == PublishingAccount.Status.REVOKED
+    assert account.access_token == ""
+
+
+def test_disconnect_is_scoped_to_the_owner(client, account, db):
+    stranger = User.objects.create_user(username="stranger", password="pw")
+    stranger.user_permissions.add(
+        Permission.objects.get(
+            codename="access_content_planner",
+            content_type__app_label="content_planner",
+        )
+    )
+    client.force_login(stranger)
+    response = client.post(
+        reverse(
+            "content_planner:publishing_account_disconnect", kwargs={"pk": account.pk}
+        )
+    )
+    assert response.status_code == 404

--- a/tests/test_content_planner_publishing.py
+++ b/tests/test_content_planner_publishing.py
@@ -32,7 +32,7 @@ from content_planner.models import (
     Publication,
     PublishingAccount,
 )
-from content_planner.payloads import build_payload, mime_for
+from content_planner.payloads import absolute_url, build_payload, mime_for
 from content_planner.preflight import Blocker, grapheme_len, preflight
 
 User = get_user_model()
@@ -329,6 +329,21 @@ def test_build_payload_renders_text_and_assets(publication, board):
     assert payload.assets[0].byte_size == 1
 
 
+def test_asset_urls_are_made_absolute_for_connectors(publication, board, settings):
+    """A connector fetches over HTTP; "/media/…" is not fetchable."""
+    settings.DOMAIN_NAME = "https://secretcodes.dev"
+    publication.post.assets.add(image(board=board))
+    assert (
+        build_payload(publication)
+        .assets[0]
+        .url.startswith("https://secretcodes.dev/media/")
+    )
+
+
+def test_absolute_url_leaves_remote_storage_alone():
+    assert absolute_url("https://spaces.test/a.jpg") == "https://spaces.test/a.jpg"
+
+
 def test_build_payload_carries_published_link(publication):
     publication.post.published_url = "https://example.test/post"
     publication.post.save()
@@ -468,6 +483,35 @@ def test_publish_one_fails_without_a_connector(publication, settings):
     assert tasks.publish_one(claim(publication).pk) == Publication.State.FAILED
     publication.refresh_from_db()
     assert "No connector" in publication.last_error
+
+
+def test_publish_one_flags_the_account_when_the_token_is_rejected(
+    publication, monkeypatch
+):
+    """A 401 is the credential's problem, not the post's: stop and ask."""
+    monkeypatch.setattr(
+        "content_planner.tasks.connector_for",
+        lambda account: FakeConnector(
+            raises=PermanentPublishError("revoked", status_code=401)
+        ),
+    )
+    assert tasks.publish_one(claim(publication).pk) == Publication.State.FAILED
+    publication.account.refresh_from_db()
+    assert publication.account.status == PublishingAccount.Status.NEEDS_REAUTH
+
+
+def test_publish_one_leaves_the_account_alone_on_a_content_rejection(
+    publication, monkeypatch
+):
+    monkeypatch.setattr(
+        "content_planner.tasks.connector_for",
+        lambda account: FakeConnector(
+            raises=PermanentPublishError("too long", status_code=422)
+        ),
+    )
+    tasks.publish_one(claim(publication).pk)
+    publication.account.refresh_from_db()
+    assert publication.account.status == PublishingAccount.Status.ACTIVE
 
 
 def test_publish_one_does_not_retry_permanent_errors(publication, monkeypatch):


### PR DESCRIPTION
The first real platform (M2 of `handoff/social-publishing.md`). Builds on the M1 skeleton: no changes to the dispatcher/retry/preflight contracts, just a connector plugged into `CONTENT_PLANNER_CONNECTORS` and a UI to connect accounts.

### Why Mastodon first

It's the only one of the three platforms with **server-side idempotency**. Publishing sends `Idempotency-Key: {publication.idempotency_key}`, and Mastodon dedupes on it, so a retry after a timeout-that-actually-succeeded returns the original status rather than double-posting. §6.3 calls this the highest-value line in the connector; it's why M2 leads.

### Connector

Everything is per-instance, read at connect time and cached in `account.metadata`:

- **Registration** — `MastodonApp` holds one client registration per instance host; `register_app()` reuses a stored one rather than re-registering.
- **OAuth** — authorize URL → callback → `verify_credentials` for the stable `id` + `acct`, then `/api/v1/instance` for the character limit and media rules. Mastodon tokens don't expire, so `expires_at` is `None` and a 401 is handled as revocation, not refresh.
- **Media** — uploaded before the status. `/api/v2/media` returns 202 while converting; the connector polls `/api/v1/media/{id}` until the URL exists and raises loudly if it never does, because attaching an unprocessed item makes a broken post. Alt text goes out as `description`.

### Transport

`connectors/transport.py` is the one place that decides retryable-vs-not, from the status code, so no connector repeats the judgement: 429 / 5xx → `TransientPublishError`, a network exception → transient (we can't know whether it landed — that's what the idempotency key covers), 4xx → `PermanentPublishError`. Every connector call has a 30s timeout so a hung request can't stall the worker's tick.

`PublishError` now carries `status_code`. `publish_one` uses it: a 401/403 flags the account `needs_reauth` and stops retrying, rather than spending the whole backoff ladder on a credential that will never work.

### Connect flow

A per-user **"Your publishing accounts"** page (linked from the boards index, follows the app-ui-conventions header/breadcrumb): connect by typing an instance, authorise there, return here. Status badges show active / needs-reconnecting / disconnected. Disconnecting an account that has delivery history **revokes** it (clears tokens, keeps the row) rather than deleting, because `Publication.account` is `PROTECT` and the history must survive; an unused account is deleted outright. All account access is scoped to `owner`.

### Smaller things

- Asset URLs are made absolute before reaching a connector (`/media/…` isn't fetchable by a remote server).
- `responses==0.26.2` added as a dev dep for mocked-HTTP tests; `requests` pinned explicitly (was transitive).

### Verification

- 1067 tests pass, 100% coverage. 40 new: app registration + reuse, OAuth exchange (including idempotent re-connect), media processing poll + timeout, the idempotency header, rate-limit→transient / validation→permanent mapping, the 401→reauth path, and the full connect/callback/disconnect flow with state-mismatch and owner-scoping cases.
- **Not verifiable here:** §6's acceptance is one real post with an image and alt text, which needs Mastodon credentials. Every HTTP exchange is covered by mocked-transport tests instead; the real-credential check is yours to run.
- Still not deployed: production needs the broker + worker container from the M1 note before any of this dispatches.