### PR TITLE
Staging environment: publishing runtime on Azure App Service

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -1,0 +1,62 @@
+name: Deploy to staging
+
+# Manual only: pick the branch to stage from the Actions tab ("Run workflow" →
+# choose the PR branch). Staging runs whatever you dispatch, so you can exercise
+# a PR before merging it. Nothing here touches prod.
+on:
+  workflow_dispatch:
+
+env:
+  IMAGE: ghcr.io/${{ github.repository }}
+  # Distinct tag so staging and prod never share an image reference.
+  TAG: staging
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Lowercase the image name
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push the staging image
+        run: |
+          # App Service is amd64; ubuntu runners are amd64, so this is native.
+          docker build --platform linux/amd64 -t "${IMAGE}:${TAG}" .
+          docker push "${IMAGE}:${TAG}"
+
+  deploy:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    strategy:
+      # One image, three roles. Each app pulls the same :staging tag; the role
+      # is fixed by its CONTAINER_ROLE app setting (set in Terraform), not here.
+      matrix:
+        app:
+          - secretcodes-staging-web
+          - secretcodes-staging-worker
+          - secretcodes-staging-beat
+    steps:
+      - name: Log in to Azure
+        uses: azure/login@v3
+        with:
+          # A service principal with Contributor on secretcodes-staging-rg.
+          # Store it as its own secret so staging and prod creds stay separate.
+          creds: ${{ secrets.AZURE_CREDENTIALS_STAGING }}
+      - name: Lowercase the image name
+        # github.repository keeps owner case (Mariatta/…); Docker refs must be
+        # lowercase, so App Service can't pull the mixed-case tag as-is.
+        run: echo "IMAGE=ghcr.io/${GITHUB_REPOSITORY,,}" >> "$GITHUB_ENV"
+      - name: Deploy the staging image
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: ${{ matrix.app }}
+          images: ${{ env.IMAGE }}:${{ env.TAG }}

--- a/docs/deployment/staging.md
+++ b/docs/deployment/staging.md
@@ -1,0 +1,133 @@
+# Deployment: staging environment
+
+A full clone of prod in its own Azure resource group, plus the social-publishing
+runtime (Redis broker + Celery worker + beat). Its purpose: run a **PR branch**
+against **its own database** so publishing can be exercised end to end before the
+change reaches prod.
+
+Staging is the same Terraform as prod, driven by a distinct `name_prefix` and a
+separate Terraform **workspace**, so an apply here can never touch prod.
+
+## What it provisions
+
+With `enable_publishing = true`, one `terraform apply` in the `staging` workspace
+creates, all prefixed `secretcodes-staging-`:
+
+| Resource | Role |
+|---|---|
+| `-rg` | resource group holding everything below |
+| `-pg` | Postgres Flexible Server — **separate database from prod** |
+| `-redis` | Azure Cache for Redis (Basic C0), the Celery broker |
+| `-web` | the web app (App Service) |
+| `-worker` | Celery worker (App Service, same image, `CONTAINER_ROLE=worker`) |
+| `-beat` | Celery beat (App Service, `CONTAINER_ROLE=beat`) |
+| `-plan` | the shared B1 App Service plan |
+
+One image, three roles. `entrypoint.sh` switches on `CONTAINER_ROLE`; the worker
+and beat run a tiny [`healthping`](../../secretcodes/healthping.py) responder so
+App Service's startup probe passes on a container that otherwise binds no port.
+
+## One-time setup
+
+1. **Staging service principal.** The deploy workflow needs Contributor on the
+   staging resource group. Create it *after* the group exists (step 4), or scope
+   it at the subscription:
+
+   ```bash
+   az ad sp create-for-rbac --name secretcodes-staging-deploy --role contributor \
+     --scopes "/subscriptions/$(az account show --query id -o tsv)/resourceGroups/secretcodes-staging-rg" \
+     --sdk-auth > creds.json
+   gh secret set AZURE_CREDENTIALS_STAGING < creds.json && rm creds.json
+   ```
+
+   Kept separate from prod's `AZURE_CREDENTIALS` so a staging deploy can't reach
+   prod.
+
+2. **tfvars.** Copy the example and fill it in:
+
+   ```bash
+   cp infra/terraform/staging.tfvars.example infra/terraform/staging.tfvars
+   ```
+
+   Secrets go in `TF_VAR_*` env vars, not the file (see the comments in it).
+   Use a **new** `postgres_admin_password`; reuse prod's `FERNET_KEY` only if you
+   intend to copy encrypted rows across, otherwise a fresh key is fine.
+
+## Provision
+
+From `infra/terraform/`:
+
+```bash
+terraform workspace new staging      # first time only
+terraform workspace select staging
+terraform apply -var-file=staging.tfvars
+```
+
+!!! warning "Always check the workspace before applying"
+    `terraform workspace show` should print `staging`. The default workspace is
+    prod. The workspace is the only thing keeping the two states apart.
+
+## Deploy a PR branch to staging
+
+1. Push the branch you want to test.
+2. Actions → **Deploy to staging** → **Run workflow** → pick the branch.
+
+   It builds that branch as `ghcr.io/<owner>/secretcodes:staging` and points all
+   three staging apps at it. Prod keeps running `:latest`, untouched.
+
+3. Watch it come up:
+
+   ```bash
+   az webapp log tail -g secretcodes-staging-rg -n secretcodes-staging-web
+   az webapp log tail -g secretcodes-staging-rg -n secretcodes-staging-worker
+   az webapp log tail -g secretcodes-staging-rg -n secretcodes-staging-beat
+   ```
+
+   `web` migrates on boot; `worker`/`beat` may crash-loop for a few seconds until
+   those migrations land (they need the `django_celery_beat` tables), then go
+   green. That is expected on a first deploy.
+
+## Verify publishing end to end
+
+1. Open `https://secretcodes-staging-web.azurewebsites.net/content/publishing/accounts/`
+   and connect a Mastodon account (use a test account).
+
+   The Mastodon redirect URI is derived from the staging host, so register
+   `https://secretcodes-staging-web.azurewebsites.net/content/publishing/connect/mastodon/callback/`
+   if the instance pins redirect URIs.
+
+2. Create a board → campaign → a **mastodon** post, set it to **scheduled** with
+   a `scheduled_at` in the past.
+
+3. Create the `Publication` (no UI for this until the M5 queue screen):
+
+   ```bash
+   az webapp ssh -g secretcodes-staging-rg -n secretcodes-staging-web
+   python manage.py shell
+   ```
+   ```python
+   from django.utils import timezone
+   from content_planner.models import Post, PublishingAccount, Publication
+   post = Post.objects.get(title="YOUR TITLE")
+   acct = PublishingAccount.objects.get(platform="mastodon")
+   Publication.objects.create(post=post, account=acct, scheduled_for=timezone.now())
+   ```
+
+4. Within a minute the `beat` log shows `Sending due task … dispatch_due_publications`,
+   the `worker` log shows `publishing … to mastodon`, and the post lands on the
+   timeline. `Publication.state` becomes `sent` with `remote_url` filled in.
+
+   Images work on staging (unlike localhost): assets live in Spaces, which
+   Mastodon can fetch.
+
+## Tear down
+
+Staging costs run while it exists. To stop paying between test sessions:
+
+```bash
+terraform workspace select staging
+terraform destroy -var-file=staging.tfvars
+```
+
+The workspace and state remain, so a later `apply` rebuilds it. Leave the default
+(prod) workspace alone.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,20 +1,59 @@
 #!/usr/bin/env sh
 set -e
 
-echo "==> Running migrations"
-python manage.py migrate --noinput
+# One image, three roles. CONTAINER_ROLE selects what this container does, so
+# the web app, the Celery worker, and beat all run the same image and differ
+# only by an env var. Defaults to "web", so any host that doesn't set it (incl.
+# prod today) behaves exactly as before.
+ROLE="${CONTAINER_ROLE:-web}"
 
-echo "==> Collecting static files"
-python manage.py collectstatic --noinput
+# Only the web role migrates: three containers racing `migrate` on deploy is
+# asking for trouble, and worker/beat come up green once web has run it. If
+# beat starts first it crash-loops on the missing django_celery_beat tables
+# and App Service restarts it until web finishes — noisy but self-healing.
+run_web() {
+    echo "==> Running migrations"
+    python manage.py migrate --noinput
 
-# App Service injects PORT (set WEBSITES_PORT=8000 in app settings so the
-# platform routes correctly). Falls back to 8000 locally.
-PORT="${PORT:-8000}"
+    echo "==> Collecting static files"
+    python manage.py collectstatic --noinput
 
-echo "==> Starting gunicorn on :${PORT}"
-exec gunicorn secretcodes.wsgi:application \
-    --bind "0.0.0.0:${PORT}" \
-    --workers 3 \
-    --timeout 60 \
-    --access-logfile - \
-    --error-logfile -
+    # App Service injects PORT (set WEBSITES_PORT=8000 in app settings so the
+    # platform routes correctly). Falls back to 8000 locally.
+    PORT="${PORT:-8000}"
+
+    echo "==> Starting gunicorn on :${PORT}"
+    exec gunicorn secretcodes.wsgi:application \
+        --bind "0.0.0.0:${PORT}" \
+        --workers 3 \
+        --timeout 60 \
+        --access-logfile - \
+        --error-logfile -
+}
+
+# App Service pings the container's port on startup and restarts it if nothing
+# answers. A Celery process binds no port, so a tiny 200-responder runs beside
+# it purely to satisfy that probe (see secretcodes/healthping.py). Harmless
+# off-Azure, where nothing pings.
+run_celery() {
+    python /code/secretcodes/healthping.py &
+    exec "$@"
+}
+
+case "$ROLE" in
+    web)
+        run_web
+        ;;
+    worker)
+        echo "==> Starting Celery worker"
+        run_celery celery -A secretcodes worker -l info
+        ;;
+    beat)
+        echo "==> Starting Celery beat"
+        run_celery celery -A secretcodes beat -l info
+        ;;
+    *)
+        echo "Unknown CONTAINER_ROLE '${ROLE}' (expected web, worker, or beat)" >&2
+        exit 1
+        ;;
+esac

--- a/infra/terraform/main.tf
+++ b/infra/terraform/main.tf
@@ -1,6 +1,9 @@
 locals {
-  app_name = "${var.name_prefix}-web"
-  pg_name  = "${var.name_prefix}-pg"
+  app_name    = "${var.name_prefix}-web"
+  worker_name = "${var.name_prefix}-worker"
+  beat_name   = "${var.name_prefix}-beat"
+  pg_name     = "${var.name_prefix}-pg"
+  redis_name  = "${var.name_prefix}-redis"
 
   # Host(s) the app answers on. With a custom apex domain bound, both the
   # azurewebsites.net hostname and the custom domain must be trusted, or Django
@@ -19,6 +22,54 @@ locals {
   # application_stack wants the image path + tag WITHOUT the registry host;
   # the host goes in docker_registry_url. Strip "ghcr.io/" from the full ref.
   docker_image_name = replace(var.image, "ghcr.io/", "")
+
+  # Celery broker. Azure Cache for Redis only accepts TLS (port 6380); rediss://
+  # + ssl_cert_reqs is what redis-py needs to connect. Only created when
+  # publishing is enabled, so guard the reference behind the same flag.
+  broker_url = var.enable_publishing ? "rediss://:${urlencode(azurerm_redis_cache.redis[0].primary_access_key)}@${azurerm_redis_cache.redis[0].hostname}:6380/0?ssl_cert_reqs=required" : ""
+
+  # Publishing-only settings, empty until the flag is on, so a non-publishing
+  # env (prod today) sees no new app settings and its apply stays a no-op.
+  # DOMAIN_NAME lives here rather than in the base: the connector uses it to
+  # build absolute asset URLs and the Mastodon redirect. (Prod not setting it
+  # is a separate, pre-existing issue — QR/survey links there fall back to the
+  # localhost default — deliberately left alone rather than folded into this.)
+  publishing_settings = var.enable_publishing ? {
+    CELERY_BROKER_URL = local.broker_url
+    DOMAIN_NAME       = "https://${local.public_host}"
+  } : {}
+
+  # Everything both the web app and the workers need. Kept in one place so the
+  # roles can't drift: the worker publishes, so it needs the DB, the encryption
+  # key, media storage, and the outbound host settings just like web does.
+  base_app_settings = {
+    DATABASE_URL = local.database_url
+    SECRET_KEY   = var.django_secret_key
+    FERNET_KEY   = var.fernet_key
+    # settings.py does DEBUG = bool(os.environ.get("DEBUG", 0)) — any non-empty
+    # string (incl. "0") is truthy, so an empty string is the only safe "off".
+    DEBUG = ""
+
+    DJANGO_ALLOWED_HOSTS = local.allowed_hosts
+    CSRF_TRUSTED_ORIGINS = local.csrf_origins
+
+    GOOGLE_CLIENT_ID          = var.google_client_id
+    GOOGLE_CLIENT_SECRET      = var.google_client_secret
+    GOOGLE_OAUTH_REDIRECT_URI = "https://${local.public_host}/availability/oauth/callback/"
+
+    DJANGO_EMAIL_HOST          = "smtp.mailgun.org"
+    DJANGO_EMAIL_PORT          = "587"
+    DJANGO_EMAIL_HOST_USER     = var.mailgun_smtp_user
+    DJANGO_EMAIL_HOST_PASSWORD = var.mailgun_smtp_password
+    DJANGO_EMAIL_USE_TLS       = "true"
+    DJANGO_DEFAULT_FROM_EMAIL  = var.default_from_email
+
+    USE_SPACES              = "true"
+    AWS_ACCESS_KEY_ID       = var.spaces_key
+    AWS_SECRET_ACCESS_KEY   = var.spaces_secret
+    AWS_STORAGE_BUCKET_NAME = var.spaces_bucket
+    AWS_S3_ENDPOINT_URL     = var.spaces_endpoint
+  }
 }
 
 resource "azurerm_resource_group" "rg" {
@@ -69,7 +120,23 @@ resource "azurerm_postgresql_flexible_server_firewall_rule" "operator" {
   end_ip_address   = var.operator_ip
 }
 
-# --- Compute: App Service plan + container web app ---------------------------
+# --- Redis: the Celery broker (publishing only) ------------------------------
+# Basic C0 (250 MB, no SLA) is plenty for a job queue that holds at most a
+# minute of work. Only the broker lives here; delivery state is in Postgres.
+
+resource "azurerm_redis_cache" "redis" {
+  count                = var.enable_publishing ? 1 : 0
+  name                 = local.redis_name
+  resource_group_name  = azurerm_resource_group.rg.name
+  location             = azurerm_resource_group.rg.location
+  capacity             = 0
+  family               = "C"
+  sku_name             = "Basic"
+  non_ssl_port_enabled = false
+  minimum_tls_version  = "1.2"
+}
+
+# --- Compute: App Service plan + container apps ------------------------------
 
 resource "azurerm_service_plan" "plan" {
   name                = "${var.name_prefix}-plan"
@@ -97,7 +164,7 @@ resource "azurerm_linux_web_app" "web" {
     }
   }
 
-  app_settings = {
+  app_settings = merge(local.base_app_settings, local.publishing_settings, {
     WEBSITES_PORT = "8000"
     # App Service kills the container if it doesn't answer the startup probe
     # within this many seconds (default 230). A large first-pull + migrate on
@@ -105,44 +172,63 @@ resource "azurerm_linux_web_app" "web" {
     # image (python:3.13-slim) + moving collectstatic to build time.
     WEBSITES_CONTAINER_START_TIME_LIMIT = "1800"
 
-    DATABASE_URL = local.database_url
-    SECRET_KEY   = var.django_secret_key
-    FERNET_KEY   = var.fernet_key
-    # settings.py does DEBUG = bool(os.environ.get("DEBUG", 0)) — any non-empty
-    # string (incl. "0") is truthy, so an empty string is the only safe "off".
-    # DEBUG must stay off in prod, which is exactly why FERNET_KEY is required.
-    DEBUG = ""
-    # The app reads DJANGO_ALLOWED_HOSTS (settings.py), not ALLOWED_HOSTS.
-    DJANGO_ALLOWED_HOSTS = local.allowed_hosts
-    # Scheme+host trusted for CSRF (Django 4.0+). App Service terminates TLS, so
-    # the browser's https:// Origin must be listed here or logins fail CSRF.
-    CSRF_TRUSTED_ORIGINS = local.csrf_origins
-
-    # Google OAuth for availability calendar sync. Reuse the Heroku client; the
-    # redirect URI must point at this host and be registered in Google Console.
-    GOOGLE_CLIENT_ID          = var.google_client_id
-    GOOGLE_CLIENT_SECRET      = var.google_client_secret
-    GOOGLE_OAUTH_REDIRECT_URI = "https://${local.public_host}/availability/oauth/callback/"
-
-    # Email (Mailgun SMTP). Heroku's addon provided this implicitly; without it
-    # settings.py falls back to localhost:25 and every email send (survey /
-    # expenses / content invites, booking notifications) 500s.
-    DJANGO_EMAIL_HOST          = "smtp.mailgun.org"
-    DJANGO_EMAIL_PORT          = "587"
-    DJANGO_EMAIL_HOST_USER     = var.mailgun_smtp_user
-    DJANGO_EMAIL_HOST_PASSWORD = var.mailgun_smtp_password
-    DJANGO_EMAIL_USE_TLS       = "true"
-    DJANGO_DEFAULT_FROM_EMAIL  = var.default_from_email
-
-    # settings.py only wires up the S3/Spaces storage (and the AWS_* settings the
-    # QR generator reads) when USE_SPACES == "true". Without it, QR creation 500s.
-    USE_SPACES              = "true"
-    AWS_ACCESS_KEY_ID       = var.spaces_key
-    AWS_SECRET_ACCESS_KEY   = var.spaces_secret
-    AWS_STORAGE_BUCKET_NAME = var.spaces_bucket
-    AWS_S3_ENDPOINT_URL     = var.spaces_endpoint
-
     # Do NOT add DOCKER_REGISTRY_SERVER_* here. The provider manages registry
     # creds via application_stack; duplicating them causes a perpetual diff.
+  })
+}
+
+# --- Celery worker + beat (publishing only) ----------------------------------
+# Same image as web, distinguished by CONTAINER_ROLE (see entrypoint.sh). They
+# serve no traffic; the healthping responder answers the startup probe so App
+# Service doesn't crash-loop a port-less container. One beat only — two would
+# double every scheduled tick.
+
+resource "azurerm_linux_web_app" "worker" {
+  count               = var.enable_publishing ? 1 : 0
+  name                = local.worker_name
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_service_plan.plan.location
+  service_plan_id     = azurerm_service_plan.plan.id
+  https_only          = true
+
+  site_config {
+    always_on = true
+    application_stack {
+      docker_image_name        = local.docker_image_name
+      docker_registry_url      = "https://ghcr.io"
+      docker_registry_username = var.ghcr_user
+      docker_registry_password = var.ghcr_pat
+    }
   }
+
+  app_settings = merge(local.base_app_settings, local.publishing_settings, {
+    CONTAINER_ROLE                      = "worker"
+    WEBSITES_PORT                       = "8000" # the healthping responder
+    WEBSITES_CONTAINER_START_TIME_LIMIT = "1800"
+  })
+}
+
+resource "azurerm_linux_web_app" "beat" {
+  count               = var.enable_publishing ? 1 : 0
+  name                = local.beat_name
+  resource_group_name = azurerm_resource_group.rg.name
+  location            = azurerm_service_plan.plan.location
+  service_plan_id     = azurerm_service_plan.plan.id
+  https_only          = true
+
+  site_config {
+    always_on = true
+    application_stack {
+      docker_image_name        = local.docker_image_name
+      docker_registry_url      = "https://ghcr.io"
+      docker_registry_username = var.ghcr_user
+      docker_registry_password = var.ghcr_pat
+    }
+  }
+
+  app_settings = merge(local.base_app_settings, local.publishing_settings, {
+    CONTAINER_ROLE                      = "beat"
+    WEBSITES_PORT                       = "8000"
+    WEBSITES_CONTAINER_START_TIME_LIMIT = "1800"
+  })
 }

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -15,6 +15,16 @@ output "postgres_fqdn" {
   value = azurerm_postgresql_flexible_server.pg.fqdn
 }
 
+output "worker_app_name" {
+  description = "Celery worker App Service name, when publishing is enabled."
+  value       = var.enable_publishing ? azurerm_linux_web_app.worker[0].name : null
+}
+
+output "beat_app_name" {
+  description = "Celery beat App Service name, when publishing is enabled."
+  value       = var.enable_publishing ? azurerm_linux_web_app.beat[0].name : null
+}
+
 output "database_url" {
   description = "Restore target for the migration. Sensitive — contains the password. View with: terraform output -raw database_url"
   value       = local.database_url

--- a/infra/terraform/staging.tfvars.example
+++ b/infra/terraform/staging.tfvars.example
@@ -1,0 +1,51 @@
+# Staging environment. Copy to staging.tfvars (gitignored) and fill in.
+#
+# Staging is the SAME config as prod, driven into its own resource group and
+# state by a distinct name_prefix + a Terraform workspace. Run it with:
+#
+#   terraform workspace new staging        # once
+#   terraform workspace select staging
+#   terraform apply -var-file=staging.tfvars
+#
+# The workspace keeps staging state separate, so an apply here can never touch
+# the prod resources tracked in the default workspace.
+#
+# Secrets still come from TF_VAR_* env vars, NOT this file:
+#   export TF_VAR_postgres_admin_password='...'   # a NEW password, not prod's
+#   export TF_VAR_ghcr_pat='...'
+#   export TF_VAR_django_secret_key='...'
+#   export TF_VAR_fernet_key='...'   # MUST match prod's if you copy encrypted
+#                                    # rows over; a fresh env can use a new key
+#   export TF_VAR_spaces_key='...' TF_VAR_spaces_secret='...'
+#   export TF_VAR_mailgun_smtp_password='...'
+#   export ARM_SUBSCRIPTION_ID='...'
+
+# Distinct prefix => secretcodes-staging-{rg,web,worker,beat,pg,redis}, all
+# separate from prod. Its own Postgres server means its own database.
+name_prefix = "secretcodes-staging"
+
+location         = "canadacentral"
+postgres_version = "16"
+
+# Turns on the Redis broker + worker + beat apps.
+enable_publishing = true
+
+# Point staging at the branch image, not :latest, so you test a PR before
+# merging it. Build + push this tag from the PR branch (see the staging deploy
+# workflow or docs/deployment/staging.md).
+image     = "ghcr.io/mariatta/secretcodes:staging"
+ghcr_user = "mariatta"
+
+postgres_db_name    = "secretcodes"
+postgres_admin_user = "scadmin"
+
+# Serve on the azurewebsites.net hostname only; no custom domain for staging.
+custom_domain = ""
+
+spaces_bucket   = "your-space-name"
+spaces_endpoint = "https://nyc3.digitaloceanspaces.com"
+
+mailgun_smtp_user = "postmaster@your-domain"
+# default_from_email = "Staging <staging@your-domain>"
+
+operator_ip = "" # your public IP if you need psql access to staging's DB

--- a/infra/terraform/variables.tf
+++ b/infra/terraform/variables.tf
@@ -22,6 +22,14 @@ variable "custom_domain" {
   default     = ""
 }
 
+# --- Publishing (Celery worker/beat + Redis broker) --------------------------
+
+variable "enable_publishing" {
+  description = "Provision the social-publishing runtime: a Redis broker plus worker and beat App Service apps. Off by default so prod stays unchanged; turn on per environment (e.g. staging)."
+  type        = bool
+  default     = false
+}
+
 # --- PostgreSQL --------------------------------------------------------------
 
 variable "postgres_version" {

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -42,6 +42,7 @@ nav:
   - Deployment:
       - Azure (App Service + Postgres): deployment/azure.md
       - Infrastructure as Code (Terraform): deployment/terraform.md
+      - Staging environment: deployment/staging.md
       - Heroku → Azure migration: deployment/migration.md
   - Runbooks: runbooks/index.md
   - Reference: reference/index.md

--- a/secretcodes/healthping.py
+++ b/secretcodes/healthping.py
@@ -1,0 +1,39 @@
+"""A minimal HTTP 200 responder for the non-web container roles.
+
+App Service pings a Linux container's port on startup and restarts it if
+nothing answers, which would crash-loop a Celery worker or beat process (they
+bind no port). This serves a trivial ``ok`` on ``$PORT`` alongside them so the
+platform's probe passes.
+
+It is deliberately not a real health check: it says nothing about whether the
+worker is consuming tasks, only that the container is up. It also serves the
+same 200 for every path so it never exposes anything, since App Service gives
+even a no-ingress app a public hostname.
+
+Run as a standalone script (``python /code/secretcodes/healthping.py``) so it
+stays pure stdlib and does not import Django or Celery.
+"""
+
+import os
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class _OK(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header("Content-Type", "text/plain")
+        self.send_header("Content-Length", "2")
+        self.end_headers()
+        self.wfile.write(b"ok")
+
+    def log_message(self, *args):
+        """Silence the default per-request stderr logging."""
+
+
+def serve(port=None):
+    port = port or int(os.environ.get("PORT", "8000"))
+    HTTPServer(("0.0.0.0", port), _OK).serve_forever()
+
+
+if __name__ == "__main__":  # pragma: no cover - process entrypoint
+    serve()

--- a/tests/test_healthping.py
+++ b/tests/test_healthping.py
@@ -1,0 +1,50 @@
+"""The startup-probe responder used by the worker/beat container roles."""
+
+import socket
+import threading
+from http.client import HTTPConnection
+
+from secretcodes import healthping
+
+
+def _free_port():
+    with socket.socket() as sock:
+        sock.bind(("127.0.0.1", 0))
+        return sock.getsockname()[1]
+
+
+def test_responds_200_ok_on_any_path():
+    port = _free_port()
+    server = healthping.HTTPServer(("127.0.0.1", port), healthping._OK)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.start()
+    try:
+        for path in ("/", "/anything", "/robots.txt"):
+            conn = HTTPConnection("127.0.0.1", port, timeout=2)
+            conn.request("GET", path)
+            response = conn.getresponse()
+            assert response.status == 200
+            assert response.read() == b"ok"
+            conn.close()
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join()
+
+
+def test_serve_reads_the_port_from_env_and_starts_the_server(monkeypatch):
+    """`serve()` blocks on serve_forever, so stub the server to observe it."""
+    seen = {}
+
+    class FakeServer:
+        def __init__(self, address, handler):
+            seen["address"] = address
+
+        def serve_forever(self):
+            seen["served"] = True
+
+    monkeypatch.setattr(healthping, "HTTPServer", FakeServer)
+    monkeypatch.setenv("PORT", "8123")
+    healthping.serve()
+    assert seen["address"] == ("0.0.0.0", 8123)
+    assert seen["served"] is True


### PR DESCRIPTION
Stacked on #142 (the M2 branch), so the staging image contains the Mastodon connector and you can exercise it before merging M2. **Merge #142 first, then retarget this to main.** Review only the infra diff here.

Answers "set up a staging env on Azure I can test before merging, with its own database." A full clone of prod in its own resource group, plus the Redis + worker + beat that publishing needs.

### One image, three roles

`entrypoint.sh` switches on `CONTAINER_ROLE` (web / worker / beat), defaulting to **web** so prod and local compose are unchanged. Only web migrates, so three containers don't race `migrate` on deploy.

`secretcodes/healthping.py` answers App Service's startup probe for worker/beat (they bind no port and would otherwise crash-loop). Returns 200 on every path so it exposes nothing; pure stdlib so it pulls in neither Django nor Celery. Tested to 100%.

### Terraform

- New `enable_publishing` flag (**default false**) gates the Redis cache and the worker/beat apps. Prod's next apply stays a **no-op** — verified the non-publishing path adds no settings.
- Shared app settings factored into one `local` so the worker (which publishes, so needs the DB, `FERNET_KEY`, media, host settings) can't drift from web.
- Staging = a separate Terraform **workspace** under `name_prefix = secretcodes-staging`, so its state and resources are wholly apart from prod. Its own `-pg` server = its own database.
- `DOMAIN_NAME` is set for publishing envs only. Its absence in prod (QR/survey links fall back to `localhost`) is a real but **pre-existing** issue, deliberately not bundled in here — flagging it for a separate fix.

### Deploy path

`deploy-staging.yml` is manual-dispatch: pick a branch → builds it as `:staging` → points the three staging apps at it. Prod keeps running `:latest`. Needs a `AZURE_CREDENTIALS_STAGING` secret (SP scoped to the staging RG, kept separate from prod's).

### Runbook

`docs/deployment/staging.md`: one-time SP + tfvars setup, `terraform workspace new staging` + apply, dispatch a PR branch, connect Mastodon, create a Publication, watch beat→worker deliver a real post, tear down with `destroy` to stop the meter.

### Compute choice

App Service (not Container Apps), per your call: staging mirrors prod's compute model, so the eventual prod publishing rollout is this same Terraform with `enable_publishing = true` and the prod names. The tradeoff is a port-less worker on a service that expects HTTP, handled by the healthping responder + `always_on`.

### Not done here

I can't `terraform apply` for you: it spends your Azure credits and needs your subscription auth. This PR is the code + runbook; provisioning is yours to run. Images work on staging (assets in Spaces are fetchable by Mastodon), unlike localhost.

### Verification

1069 tests pass, 100% coverage. `tofu validate` passes; `tofu fmt` clean on the changed files. Entrypoint role dispatch and the healthping responder both exercised in a container locally.