### PR TITLE
Docs: use `tofu` in command examples, not `terraform`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,8 +26,9 @@ media/
 # Build state
 .state/
 
-# Terraform — never commit state or filled-in vars (the *.example IS committed)
-infra/terraform/terraform.tfvars
+# Terraform — never commit state or filled-in vars (the *.example IS committed;
+# *.tfvars matches staging.tfvars / terraform.tfvars but not *.tfvars.example)
+infra/terraform/*.tfvars
 *.tfstate
 *.tfstate.*
 .terraform/

--- a/docs/deployment/migration.md
+++ b/docs/deployment/migration.md
@@ -8,7 +8,7 @@ the day of leaving Azure.
 | Piece | Automated? | How |
 |---|---|---|
 | Build + ship the app | Fully | `deploy.yml` on push to `main` |
-| Provision infra | Fully | `terraform apply` |
+| Provision infra | Fully | `tofu apply` |
 | Database cutover | Scripted but **human-supervised** | the steps below |
 
 The DB cutover stays manual on purpose: it's a maintenance window with a point

--- a/docs/deployment/staging.md
+++ b/docs/deployment/staging.md
@@ -10,7 +10,7 @@ separate Terraform **workspace**, so an apply here can never touch prod.
 
 ## What it provisions
 
-With `enable_publishing = true`, one `terraform apply` in the `staging` workspace
+With `enable_publishing = true`, one `tofu apply` in the `staging` workspace
 creates, all prefixed `secretcodes-staging-`:
 
 | Resource | Role |
@@ -58,13 +58,13 @@ App Service's startup probe passes on a container that otherwise binds no port.
 From `infra/terraform/`:
 
 ```bash
-terraform workspace new staging      # first time only
-terraform workspace select staging
-terraform apply -var-file=staging.tfvars
+tofu workspace new staging      # first time only
+tofu workspace select staging
+tofu apply -var-file=staging.tfvars
 ```
 
 !!! warning "Always check the workspace before applying"
-    `terraform workspace show` should print `staging`. The default workspace is
+    `tofu workspace show` should print `staging`. The default workspace is
     prod. The workspace is the only thing keeping the two states apart.
 
 ## Deploy a PR branch to staging
@@ -125,8 +125,8 @@ terraform apply -var-file=staging.tfvars
 Staging costs run while it exists. To stop paying between test sessions:
 
 ```bash
-terraform workspace select staging
-terraform destroy -var-file=staging.tfvars
+tofu workspace select staging
+tofu destroy -var-file=staging.tfvars
 ```
 
 The workspace and state remain, so a later `apply` rebuilds it. Leave the default

--- a/docs/deployment/terraform.md
+++ b/docs/deployment/terraform.md
@@ -4,6 +4,10 @@ The Azure side is provisioned with Terraform, in `infra/terraform/`. This is the
 declarative successor to the earlier `provision-azure.sh` script, same
 resources, but reproducible, reviewable, and diffable.
 
+The CLI here is **OpenTofu** (`tofu`), the drop-in fork: the `.tf` config,
+`TF_VAR_*` env vars, and every subcommand are identical to Terraform's, only the
+command name differs. Substitute `terraform` if that's what you have installed.
+
 ## What it creates
 
 | Resource | Terraform resource | Notes |
@@ -37,12 +41,12 @@ export TF_VAR_spaces_key='...' TF_VAR_spaces_secret='...'
 
 cp terraform.tfvars.example terraform.tfvars   # edit non-secret values
 
-terraform init
-terraform plan      # review what will change
-terraform apply
+tofu init
+tofu plan      # review what will change
+tofu apply
 
 # The restore target for the DB migration:
-terraform output -raw database_url
+tofu output -raw database_url
 ```
 
 ## Gotchas worth knowing

--- a/infra/terraform/outputs.tf
+++ b/infra/terraform/outputs.tf
@@ -26,7 +26,7 @@ output "beat_app_name" {
 }
 
 output "database_url" {
-  description = "Restore target for the migration. Sensitive — contains the password. View with: terraform output -raw database_url"
+  description = "Restore target for the migration. Sensitive — contains the password. View with: tofu output -raw database_url"
   value       = local.database_url
   sensitive   = true
 }

--- a/infra/terraform/providers.tf
+++ b/infra/terraform/providers.tf
@@ -9,7 +9,7 @@ terraform {
   }
 
   # Remote state keeps the source of truth off your laptop. Commented out so the
-  # first `terraform init` works locally with zero setup. When ready, create a
+  # first `tofu init` works locally with zero setup. When ready, create a
   # state container and uncomment. The backend is itself a portability choice:
   # azurerm below ties state to Azure; if you'd rather keep state vendor-neutral
   # you can use an S3-compatible backend pointed at DigitalOcean Spaces instead.

--- a/infra/terraform/staging.tfvars.example
+++ b/infra/terraform/staging.tfvars.example
@@ -3,9 +3,9 @@
 # Staging is the SAME config as prod, driven into its own resource group and
 # state by a distinct name_prefix + a Terraform workspace. Run it with:
 #
-#   terraform workspace new staging        # once
-#   terraform workspace select staging
-#   terraform apply -var-file=staging.tfvars
+#   tofu workspace new staging        # once
+#   tofu workspace select staging
+#   tofu apply -var-file=staging.tfvars
 #
 # The workspace keeps staging state separate, so an apply here can never touch
 # the prod resources tracked in the default workspace.


### PR DESCRIPTION
The repo's Terraform CLI is OpenTofu (`tofu`), and `migration.md` already used `tofu -chdir=…`, but the other deployment docs and the infra comments still wrote `terraform <subcommand>`, which fails on a tofu-only machine (as I just hit while walking through the staging setup).

Switches every **command invocation** to `tofu`:

- `docs/deployment/staging.md`, `terraform.md`, `migration.md`
- `infra/terraform/staging.tfvars.example`, `outputs.tf`, `providers.tf` (comments)

Plus a one-line note in `terraform.md` that the CLI is OpenTofu: identical `.tf` config, `TF_VAR_*` env vars, and subcommands, only the command name differs, and `terraform` works if that's what you have.

Left alone on purpose: the product-name prose ("provisioned with Terraform"), the `terraform.tfvars` filename, and the `-chdir=infra/terraform` directory paths (a blind replace briefly mangled those into `infra/tofu` — caught and reverted; `tofu validate` passes).

Docs-only, no code change.